### PR TITLE
feat: adicionar contador de comentários nos cards

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,7 +171,8 @@ def listar_carros():
                 c.aro_roda,
                 c.foto_url,
                 c.historia,
-                COUNT(cur.id) AS total_curtidas,
+                COUNT(DISTINCT cur.id) AS total_curtidas,
+                COUNT(DISTINCT com.id) AS total_comentarios,
                 CASE 
                     WHEN SUM(CASE WHEN cur.usuario_id = %s THEN 1 ELSE 0 END) > 0 
                     THEN 1 
@@ -179,6 +180,7 @@ def listar_carros():
                 END AS curtido_pelo_usuario
             FROM carros c
             LEFT JOIN curtidas cur ON c.id = cur.carro_id
+            LEFT JOIN comentarios com ON c.id = com.carro_id
             WHERE 1=1
         """
 

--- a/index.html
+++ b/index.html
@@ -1137,7 +1137,7 @@
                                     </span>
 
                                     <span class="comment-btn">
-                                        💬
+                                        💬 ${carro.total_comentarios || 0}
                                     </span>
                                 </div>
 
@@ -1595,6 +1595,7 @@
                 if (res.ok) {
                     input.value = '';
                     carregarComentarios(carroId);
+                    carregarGaragem();
                 } else {
                     const erro = await res.json();
                     alert(erro.erro || "Erro ao comentar.");


### PR DESCRIPTION
## Resumo

- Adiciona `total_comentarios` na listagem de carros
- Exibe o contador de comentários nos cards da garagem
- Atualiza a garagem após publicar um comentário para refletir o novo contador

## Issue relacionada

Closes #26

## Testes manuais sugeridos

- Verificar se os cards mostram `💬 0` quando não há comentários
- Verificar se os cards mostram o número correto quando há comentários
- Publicar um comentário pelo modal e conferir se o contador atualiza
- Conferir se curtida/descurtida continua funcionando
- Conferir se “Ver projeto”, “Todos os projetos” e “Meus projetos” continuam funcionando