### PR TITLE
feat: permitir deletar o próprio comentário

### DIFF
--- a/app.py
+++ b/app.py
@@ -544,6 +544,59 @@ def cadastrar_comentario(id):
 
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
+    
+@app.route('/comentarios/<int:id>', methods=['DELETE'])
+def excluir_comentario(id):
+    dados = request.json
+    usuario_id = str(dados.get('usuario_id', '')).strip()
+
+    if not usuario_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, usuario_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário inválido."}), 403
+
+        cursor.execute(
+            """
+            SELECT id, usuario_id
+            FROM comentarios
+            WHERE id = %s
+            """,
+            (id,)
+        )
+
+        comentario = cursor.fetchone()
+
+        if not comentario:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Comentário não encontrado."}), 404
+
+        if str(comentario['usuario_id']) != usuario_id:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Você não tem permissão para remover este comentário."}), 403
+
+        cursor.execute(
+            "DELETE FROM comentarios WHERE id = %s",
+            (id,)
+        )
+
+        conexao.commit()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify({"mensagem": "Comentário removido com sucesso!"}), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
 
 @app.route('/usuarios/<int:id>', methods=['GET'])
 def buscar_usuario(id):

--- a/index.html
+++ b/index.html
@@ -529,6 +529,23 @@
             font-size: 0.75em;
         }
 
+        .btn-remover-comentario {
+            width: auto;
+            padding: 4px 8px;
+            margin: 0;
+            background: transparent;
+            border: 1px solid #333;
+            color: #888;
+            border-radius: 6px;
+            font-size: 0.7em;
+            cursor: pointer;
+        }
+
+        .btn-remover-comentario:hover {
+            border-color: #ff4757;
+            color: #ff4757;
+        }
+
         .comentario-texto {
             color: #ccc;
             line-height: 1.4;
@@ -1521,6 +1538,7 @@
             try {
                 const res = await fetch(`${API_URL}/carros/${carroId}/comentarios`);
                 const comentarios = await res.json();
+                const usuario = getUsuarioLogado();
 
                 const lista = document.getElementById('lista-comentarios');
                 lista.innerHTML = '';
@@ -1545,9 +1563,21 @@
                                     </span>`
                                 }
 
-                                <span class="comentario-data">
-                                    ${new Date(c.criado_em).toLocaleString()}
-                                </span>
+                                <div style="display: flex; gap: 8px; align-items: center;">
+                                    <span class="comentario-data">
+                                        ${new Date(c.criado_em).toLocaleString()}
+                                    </span>
+
+                                    ${usuario && String(usuario.id) === String(c.usuario_id) ? `
+                                        <button 
+                                            type="button" 
+                                            class="btn-remover-comentario" 
+                                            onclick="excluirComentario(${c.id}, ${carroId})"
+                                        >
+                                            Remover
+                                        </button>
+                                    ` : ''}
+                                </div>
                             </div>
 
                             <div class="comentario-texto">
@@ -1599,6 +1629,46 @@
                 } else {
                     const erro = await res.json();
                     alert(erro.erro || "Erro ao comentar.");
+                }
+
+            } catch (error) {
+                console.error(error);
+                alert("Erro de conexão.");
+            }
+        }
+
+        async function excluirComentario(comentarioId, carroId) {
+            const usuario = getUsuarioLogado();
+
+            if (!usuario) {
+                alert("Você precisa estar logado para remover um comentário.");
+                return;
+            }
+
+            const confirmar = confirm("Remover este comentário?");
+
+            if (!confirmar) {
+                return;
+            }
+
+            try {
+                const res = await fetch(`${API_URL}/comentarios/${comentarioId}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        usuario_id: usuario.id
+                    })
+                });
+
+                const resposta = await res.json();
+
+                if (res.ok) {
+                    carregarComentarios(carroId);
+                    carregarGaragem();
+                } else {
+                    alert(resposta.erro || "Erro ao remover comentário.");
                 }
 
             } catch (error) {


### PR DESCRIPTION
## Resumo

- Adiciona rota para remover comentários por ID
- Valida se o comentário pertence ao usuário antes de excluir
- Exibe botão “Remover” apenas nos próprios comentários
- Atualiza a lista de comentários e o contador dos cards após remover

## Issue relacionada

Closes #28

## Testes manuais realizados

- Criar comentário logado
- Verificar se o botão “Remover” aparece apenas no próprio comentário
- Remover comentário e conferir se ele desaparece do modal
- Conferir se o contador de comentários no card atualiza
- Verificar se comentários, modal e curtidas continuam funcionando