### PR TITLE
feat: implementar sistema de seguir usuarios

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,20 +600,36 @@ def excluir_comentario(id):
 
 @app.route('/usuarios/<int:id>', methods=['GET'])
 def buscar_usuario(id):
+    usuario_logado_id = request.args.get('usuario_logado_id')
+
     try:
         conexao = mysql.connector.connect(**db_config)
         cursor = conexao.cursor(dictionary=True)
 
         cursor.execute("""
             SELECT 
-                id,
-                nome,
-                criado_em,
-                avatar_url,
-                bio
-            FROM usuarios
-            WHERE id = %s
-        """, (id,))
+                u.id,
+                u.nome,
+                u.criado_em,
+                u.avatar_url,
+                u.bio,
+                COUNT(DISTINCT s1.id) AS total_seguidores,
+                COUNT(DISTINCT s2.id) AS total_seguindo,
+                CASE
+                    WHEN COUNT(DISTINCT s3.id) > 0
+                    THEN 1
+                    ELSE 0
+                END AS seguido_pelo_usuario
+            FROM usuarios u
+            LEFT JOIN seguidores s1 ON u.id = s1.seguido_id
+            LEFT JOIN seguidores s2 ON u.id = s2.seguidor_id
+            LEFT JOIN seguidores s3 ON u.id = s3.seguido_id AND s3.seguidor_id = %s
+            WHERE u.id = %s
+            GROUP BY u.id
+        """, (
+            usuario_logado_id if usuario_logado_id else 0,
+            id
+        ))
 
         usuario = cursor.fetchone()
 
@@ -636,6 +652,96 @@ def buscar_usuario(id):
         conexao.close()
 
         return jsonify(usuario), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
+@app.route('/usuarios/<int:id>/seguir', methods=['POST'])
+def seguir_usuario(id):
+    dados = request.json
+    seguidor_id = str(dados.get('usuario_id', '')).strip()
+
+    if not seguidor_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    if str(id) == seguidor_id:
+        return jsonify({"erro": "Você não pode seguir a si mesmo."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, seguidor_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário inválido."}), 403
+
+        if not usuario_existe(cursor, id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Perfil não encontrado."}), 404
+
+        cursor.execute(
+            """
+            INSERT INTO seguidores (seguidor_id, seguido_id)
+            VALUES (%s, %s)
+            """,
+            (seguidor_id, id)
+        )
+
+        conexao.commit()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify({"mensagem": "Usuário seguido com sucesso!"}), 201
+
+    except mysql.connector.IntegrityError:
+        try:
+            cursor.close()
+            conexao.close()
+        except:
+            pass
+
+        return jsonify({"erro": "Você já segue este usuário."}), 409
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
+@app.route('/usuarios/<int:id>/seguir', methods=['DELETE'])
+def deixar_de_seguir_usuario(id):
+    dados = request.json
+    seguidor_id = str(dados.get('usuario_id', '')).strip()
+
+    if not seguidor_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    if str(id) == seguidor_id:
+        return jsonify({"erro": "Você não pode deixar de seguir a si mesmo."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, seguidor_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário inválido."}), 403
+
+        cursor.execute(
+            """
+            DELETE FROM seguidores
+            WHERE seguidor_id = %s AND seguido_id = %s
+            """,
+            (seguidor_id, id)
+        )
+
+        conexao.commit()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify({"mensagem": "Usuário deixou de ser seguido."}), 200
 
     except Exception as e:
         return jsonify({"erro": str(e)}), 500

--- a/index.html
+++ b/index.html
@@ -762,6 +762,50 @@
                 resize: vertical;
             }
 
+            .btn-editar-perfil,
+            .btn-seguir-perfil {
+                width: auto;
+                min-width: 150px;
+                max-width: 220px;
+                margin: 16px auto 0 auto;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                padding: 9px 18px;
+                border-radius: 999px;
+                cursor: pointer;
+                font-weight: 800;
+                letter-spacing: 0.04em;
+                text-transform: uppercase;
+                font-size: 0.8em;
+            }
+
+            .btn-editar-perfil {
+                background: transparent;
+                color: #ff4757;
+                border: 1px solid #ff4757;
+            }
+
+            .btn-editar-perfil:hover {
+                background: rgba(255, 71, 87, 0.12);
+            }
+
+            .btn-seguir-perfil {
+                background: #ff4757;
+                color: white;
+                border: 1px solid #ff4757;
+            }
+
+            .btn-seguir-perfil.seguindo {
+                background: transparent;
+                color: #ff4757;
+                border: 1px solid #ff4757;
+            }
+
+            .btn-seguir-perfil:hover {
+                transform: translateY(-1px);
+            }
+
             .btn-salvar-perfil {
                 background: #ff4757;
                 color: white;
@@ -785,22 +829,30 @@
             .perfil-stats {
                 display: flex;
                 justify-content: center;
-                margin-top: 10px;
+                gap: 34px;
+                margin: 18px 0 10px 0;
+                flex-wrap: wrap;
             }
 
             .perfil-stat {
+                min-width: 86px;
                 text-align: center;
             }
 
             .perfil-stat strong {
                 display: block;
-                font-size: 1.4em;
                 color: #ff4757;
+                font-size: 1.55em;
+                line-height: 1;
+                margin-bottom: 8px;
             }
 
             .perfil-stat span {
-                font-size: 0.8em;
+                display: block;
                 color: #aaa;
+                font-size: 0.78em;
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
             }
 
             .perfil-grid {
@@ -1806,7 +1858,9 @@
             document.body.style.overflow = "hidden";
 
             try {
-                const resUser = await fetch(`${API_URL}/usuarios/${usuarioId}`);
+                const usuarioLogadoAtual = getUsuarioLogado();
+                const queryUsuarioLogado = usuarioLogadoAtual ? `?usuario_logado_id=${usuarioLogadoAtual.id}` : '';
+                const resUser = await fetch(`${API_URL}/usuarios/${usuarioId}${queryUsuarioLogado}`);
 
                 if (!resUser.ok) {
                     alert("Perfil não disponível.");
@@ -1814,7 +1868,7 @@
                 }
 
                 const usuario = await resUser.json();
-                const usuarioLogado = getUsuarioLogado();
+                const usuarioLogado = usuarioLogadoAtual;
                 const perfilProprio = usuarioLogado && String(usuarioLogado.id) === String(usuario.id);
                 const resCarros = await fetch(`${API_URL}/usuarios/${usuarioId}/carros`);
                 const carros = await resCarros.json();
@@ -1828,7 +1882,7 @@
                     : "Esse usuário ainda não adicionou uma bio.";
 
                 const formularioEdicaoPerfil = perfilProprio ? `
-                    <div class="perfil-edicao">
+                    <div class="perfil-edicao" id="perfil-edicao" style="display: none;">
                         <input 
                             type="text" 
                             id="perfil-avatar-url" 
@@ -1852,6 +1906,26 @@
                     </div>
                 ` : '';
 
+                const botaoEditarPerfil = perfilProprio ? `
+                    <button
+                        type="button"
+                        class="btn-editar-perfil"
+                        onclick="mostrarEdicaoPerfil()"
+                    >
+                        Editar perfil
+                    </button>
+                ` : '';
+
+                const botaoSeguirPerfil = !perfilProprio && usuarioLogado ? `
+                    <button
+                        type="button"
+                        class="btn-seguir-perfil ${usuario.seguido_pelo_usuario ? 'seguindo' : ''}"
+                        onclick="alternarSeguir(${usuario.id}, ${usuario.seguido_pelo_usuario ? 'true' : 'false'})"
+                    >
+                        ${usuario.seguido_pelo_usuario ? 'Seguindo' : 'Seguir'}
+                    </button>
+                ` : '';
+
                 modalContent.innerHTML = `
                     <button class="modal-fechar" onclick="fecharModalProjeto()">X</button>
 
@@ -1867,9 +1941,23 @@
                                     <strong>${usuario.total_projetos}</strong>
                                     <span>Projetos</span>
                                 </div>
+
+                                <div class="perfil-stat">
+                                    <strong>${usuario.total_seguidores || 0}</strong>
+                                    <span>Seguidores</span>
+                                </div>
+
+                                <div class="perfil-stat">
+                                    <strong>${usuario.total_seguindo || 0}</strong>
+                                    <span>Seguindo</span>
+                                </div>
                             </div>
 
                             <p class="perfil-bio">${bioPerfil}</p>
+
+                            ${botaoSeguirPerfil}
+                            ${botaoEditarPerfil}
+
                             ${formularioEdicaoPerfil}
                         </div>
 
@@ -1944,6 +2032,50 @@
                     abrirPerfil(usuarioId);
                 } else {
                     alert(resposta.erro || "Erro ao salvar perfil.");
+                }
+
+            } catch (error) {
+                console.error(error);
+                alert("Erro de conexão.");
+            }
+        }
+
+        function mostrarEdicaoPerfil() {
+            const form = document.getElementById('perfil-edicao');
+
+            if (!form) {
+                return;
+            }
+
+            const estaAberto = form.style.display === 'block';
+            form.style.display = estaAberto ? 'none' : 'block';
+        }
+
+        async function alternarSeguir(usuarioId, jaSegue) {
+            const usuarioLogado = getUsuarioLogado();
+
+            if (!usuarioLogado) {
+                alert("Você precisa estar logado para seguir usuários.");
+                return;
+            }
+
+            try {
+                const res = await fetch(`${API_URL}/usuarios/${usuarioId}/seguir`, {
+                    method: jaSegue ? 'DELETE' : 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        usuario_id: usuarioLogado.id
+                    })
+                });
+
+                const resposta = await res.json();
+
+                if (res.ok) {
+                    abrirPerfil(usuarioId);
+                } else {
+                    alert(resposta.erro || "Erro ao atualizar follow.");
                 }
 
             } catch (error) {


### PR DESCRIPTION
## Resumo

- Cria sistema de seguir/deixar de seguir usuários
- Atualiza o endpoint de perfil para retornar contadores sociais
- Retorna se o usuário logado já segue o perfil aberto
- Adiciona botão `Seguir` / `Seguindo` no perfil de outros usuários
- Oculta botão de seguir no próprio perfil
- Exibe contadores de projetos, seguidores e seguindo
- Melhora espaçamento visual dos stats do perfil
- Esconde edição de perfil atrás do botão `Editar perfil`

## Issue relacionada

Closes #34

## Observação de banco

Para esta feature funcionar localmente, a tabela precisa existir:

```sql
CREATE TABLE seguidores (
    id INT AUTO_INCREMENT PRIMARY KEY,
    seguidor_id INT NOT NULL,
    seguido_id INT NOT NULL,
    criado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

    UNIQUE (seguidor_id, seguido_id),

    FOREIGN KEY (seguidor_id) REFERENCES usuarios(id) ON DELETE CASCADE,
    FOREIGN KEY (seguido_id) REFERENCES usuarios(id) ON DELETE CASCADE
);
```

## Testes manuais sugeridos

- Abrir perfil de outro usuário logado
- Clicar em `Seguir`
- Conferir se o botão muda para `Seguindo`
- Conferir se o contador de seguidores aumenta
- Clicar em `Seguindo`
- Conferir se volta para `Seguir`
- Conferir se o contador diminui
- Abrir o próprio perfil e confirmar que não aparece botão de seguir
- Conferir que o botão `Editar perfil` abre/fecha o formulário
- Conferir se avatar, bio, cards do perfil, curtidas e comentários continuam funcionando