### PR TITLE
feat: adicionar upload de avatar no perfil

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+import time
 from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
 import mysql.connector
@@ -55,7 +56,7 @@ def usuario_existe(cursor, usuario_id):
     return cursor.fetchone() is not None
 
 
-@app.route('/uploads/<filename>')
+@app.route('/uploads/<path:filename>')
 def uploaded_file(filename):
     return send_from_directory(app.config['UPLOAD_FOLDER'], filename)
 
@@ -805,6 +806,68 @@ def atualizar_usuario(id):
         conexao.close()
 
         return jsonify(usuario), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
+@app.route('/usuarios/<int:id>/avatar', methods=['POST'])
+def upload_avatar(id):
+    usuario_id = request.form.get('usuario_id')
+
+    if not usuario_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    if str(usuario_id) != str(id):
+        return jsonify({"erro": "Sem permissão."}), 403
+
+    if 'arquivo' not in request.files:
+        return jsonify({"erro": "Arquivo não enviado."}), 400
+
+    arquivo = request.files['arquivo']
+
+    if arquivo.filename == '':
+        return jsonify({"erro": "Arquivo inválido."}), 400
+
+    try:
+        extensoes_permitidas = ['png', 'jpg', 'jpeg', 'webp']
+
+        nome = secure_filename(arquivo.filename)
+        extensao = nome.rsplit('.', 1)[-1].lower()
+
+        if extensao not in extensoes_permitidas:
+            return jsonify({"erro": "Formato de imagem não permitido."}), 400
+
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor()
+
+        if not usuario_existe(cursor, id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário inválido."}), 404
+
+        nome_arquivo = f"user_{id}_{int(time.time())}.{extensao}"
+
+        pasta_avatars = os.path.join('uploads', 'avatars')
+        os.makedirs(pasta_avatars, exist_ok=True)
+
+        caminho = os.path.join(pasta_avatars, nome_arquivo)
+
+        arquivo.save(caminho)
+
+        cursor.execute(
+            "UPDATE usuarios SET avatar_url = %s WHERE id = %s",
+            (f"avatars/{nome_arquivo}", id)
+        )
+
+        conexao.commit()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify({
+            "mensagem": "Avatar atualizado com sucesso!",
+            "avatar_url": f"avatars/{nome_arquivo}"
+        }), 200
 
     except Exception as e:
         return jsonify({"erro": str(e)}), 500

--- a/index.html
+++ b/index.html
@@ -745,6 +745,15 @@
                 background: #101010;
             }
 
+            .perfil-label {
+                display: block;
+                color: #888;
+                font-size: 0.72em;
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
+                margin: 8px 0 6px 0;
+            }
+
             .perfil-edicao input,
             .perfil-edicao textarea {
                 width: 100%;
@@ -1873,8 +1882,14 @@
                 const resCarros = await fetch(`${API_URL}/usuarios/${usuarioId}/carros`);
                 const carros = await resCarros.json();
                 const inicialPerfil = usuario.nome ? usuario.nome.charAt(0).toUpperCase() : "?";
-                const avatarPerfil = usuario.avatar_url
-                    ? `<img src="${usuario.avatar_url}" alt="Avatar de ${usuario.nome}" class="perfil-avatar">`
+                const avatarSrc = usuario.avatar_url
+                    ? (usuario.avatar_url.startsWith('http')
+                        ? usuario.avatar_url
+                        : `${API_URL}/uploads/${usuario.avatar_url}`)
+                    : '';
+
+                const avatarPerfil = avatarSrc
+                    ? `<img src="${avatarSrc}" alt="" class="perfil-avatar">`
                     : `<div class="perfil-avatar-fallback">${inicialPerfil}</div>`;
 
                 const bioPerfil = usuario.bio && usuario.bio.trim()
@@ -1883,21 +1898,30 @@
 
                 const formularioEdicaoPerfil = perfilProprio ? `
                     <div class="perfil-edicao" id="perfil-edicao" style="display: none;">
-                        <input 
-                            type="text" 
-                            id="perfil-avatar-url" 
-                            placeholder="URL do avatar"
+                        <input
+                            type="hidden"
+                            id="perfil-avatar-atual"
                             value="${usuario.avatar_url || ''}"
                         >
 
-                        <textarea 
+                        <label class="perfil-label">
+                            Foto de perfil
+                        </label>
+
+                        <input
+                            type="file"
+                            id="perfil-avatar-arquivo"
+                            accept="image/png, image/jpeg, image/webp"
+                        >
+
+                        <textarea
                             id="perfil-bio"
                             maxlength="280"
                             placeholder="Escreva uma bio curta sobre você e sua garagem..."
                         >${usuario.bio || ''}</textarea>
 
-                        <button 
-                            type="button" 
+                        <button
+                            type="button"
                             class="btn-salvar-perfil"
                             onclick="salvarPerfil(${usuario.id})"
                         >
@@ -2004,10 +2028,50 @@
                 return;
             }
 
-            const avatarInput = document.getElementById('perfil-avatar-url');
+            const avatarArquivoInput = document.getElementById('perfil-avatar-arquivo');
+            const avatarAtualInput = document.getElementById('perfil-avatar-atual');
             const bioInput = document.getElementById('perfil-bio');
 
+            let avatarUrlFinal = avatarAtualInput ? avatarAtualInput.value : '';
+
             try {
+                if (avatarArquivoInput && avatarArquivoInput.files.length > 0) {
+                    const arquivoAvatar = avatarArquivoInput.files[0];
+
+                    const tamanhoMaximoMB = 3;
+                    const tamanhoMaximoBytes = tamanhoMaximoMB * 1024 * 1024;
+
+                    if (arquivoAvatar.size > tamanhoMaximoBytes) {
+                        alert(`A imagem deve ter no máximo ${tamanhoMaximoMB}MB.`);
+                        return;
+                    }
+
+                    const tiposPermitidos = ['image/png', 'image/jpeg', 'image/webp'];
+
+                    if (!tiposPermitidos.includes(arquivoAvatar.type)) {
+                        alert("Formato não permitido. Use PNG, JPG, JPEG ou WEBP.");
+                        return;
+                    }
+
+                    const formData = new FormData();
+                    formData.append('usuario_id', usuarioLogado.id);
+                    formData.append('arquivo', arquivoAvatar);
+
+                    const resAvatar = await fetch(`${API_URL}/usuarios/${usuarioId}/avatar`, {
+                        method: 'POST',
+                        body: formData
+                    });
+
+                    const respostaAvatar = await resAvatar.json();
+
+                    if (!resAvatar.ok) {
+                        alert(respostaAvatar.erro || "Erro ao enviar avatar.");
+                        return;
+                    }
+
+                    avatarUrlFinal = respostaAvatar.avatar_url;
+                }
+
                 const res = await fetch(`${API_URL}/usuarios/${usuarioId}`, {
                     method: 'PUT',
                     headers: {
@@ -2015,7 +2079,7 @@
                     },
                     body: JSON.stringify({
                         usuario_id: usuarioLogado.id,
-                        avatar_url: avatarInput.value.trim(),
+                        avatar_url: avatarUrlFinal,
                         bio: bioInput.value.trim()
                     })
                 });
@@ -2035,8 +2099,8 @@
                 }
 
             } catch (error) {
-                console.error(error);
-                alert("Erro de conexão.");
+                console.error("Erro ao salvar perfil:", error);
+                alert("Erro de conexão. Veja o console do navegador e o terminal do Flask.");
             }
         }
 


### PR DESCRIPTION
Closes #36

## Resumo
- Adiciona upload de avatar pelo dispositivo
- Salva imagens em `uploads/avatars`
- Atualiza o `avatar_url` do usuário
- Ajusta carregamento de avatars salvos localmente
- Remove campo manual de URL do avatar do formulário de edição
- Mantém avatar atual ao salvar apenas a bio

## Testes
- Upload de imagem menor que 3MB
- Validação de formato PNG/JPG/JPEG/WEBP
- Avatar carregando no perfil
- Bio salva sem apagar avatar existente