### PR TITLE
feat: adicionar username único aos usuários

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import time
+import re
 from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
 import mysql.connector
@@ -55,6 +56,18 @@ def usuario_existe(cursor, usuario_id):
     cursor.execute("SELECT id FROM usuarios WHERE id = %s", (usuario_id,))
     return cursor.fetchone() is not None
 
+def validar_username(username):
+    if not username:
+        return "Preencha o username."
+
+    if len(username) < 3 or len(username) > 30:
+        return "O username deve ter entre 3 e 30 caracteres."
+
+    if not re.fullmatch(r"[a-z0-9._]+", username):
+        return "O username deve conter apenas letras minúsculas, números, ponto e underline."
+
+    return None
+
 
 @app.route('/uploads/<path:filename>')
 def uploaded_file(filename):
@@ -66,11 +79,17 @@ def cadastrar_usuario():
     dados = request.json
 
     nome = str(dados.get('nome', '')).strip()
+    username = str(dados.get('username', '')).strip().lower()
     email = str(dados.get('email', '')).strip().lower()
     senha = str(dados.get('senha', '')).strip()
 
-    if not nome or not email or not senha:
-        return jsonify({"erro": "Preencha nome, email e senha."}), 400
+    if not nome or not username or not email or not senha:
+        return jsonify({"erro": "Preencha nome, username, email e senha."}), 400
+
+    erro_username = validar_username(username)
+
+    if erro_username:
+        return jsonify({"erro": erro_username}), 400
 
     try:
         conexao = mysql.connector.connect(**db_config)
@@ -83,15 +102,23 @@ def cadastrar_usuario():
             cursor.close()
             conexao.close()
             return jsonify({"erro": "Este email já está cadastrado."}), 400
+        
+        cursor.execute("SELECT id FROM usuarios WHERE username = %s", (username,))
+        username_existente = cursor.fetchone()
+
+        if username_existente:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Este username já está em uso."}), 400
 
         senha_hash = generate_password_hash(senha)
 
         cursor.execute(
             """
-            INSERT INTO usuarios (nome, email, senha)
-            VALUES (%s, %s, %s)
+            INSERT INTO usuarios (nome, username, email, senha)
+            VALUES (%s, %s, %s, %s)
             """,
-            (nome, email, senha_hash)
+            (nome, username, email, senha_hash)
         )
 
         conexao.commit()
@@ -120,7 +147,7 @@ def login_usuario():
         cursor = conexao.cursor(dictionary=True)
 
         cursor.execute(
-            "SELECT id, nome, email, senha FROM usuarios WHERE email = %s",
+            "SELECT id, nome, username, email, senha FROM usuarios WHERE email = %s",
             (email,)
         )
 
@@ -140,6 +167,7 @@ def login_usuario():
             "usuario": {
                 "id": usuario['id'],
                 "nome": usuario['nome'],
+                "username": usuario['username'],
                 "email": usuario['email']
             }
         }), 200
@@ -478,7 +506,8 @@ def listar_comentarios(id):
                 comentarios.texto,
                 comentarios.criado_em,
                 usuarios.id AS usuario_id,
-                usuarios.nome AS nome_usuario
+                usuarios.nome AS nome_usuario,
+                usuarios.username AS username_usuario
             FROM comentarios
             INNER JOIN usuarios ON comentarios.usuario_id = usuarios.id
             WHERE comentarios.carro_id = %s
@@ -611,6 +640,7 @@ def buscar_usuario(id):
             SELECT 
                 u.id,
                 u.nome,
+                u.username,
                 u.criado_em,
                 u.avatar_url,
                 u.bio,
@@ -793,7 +823,7 @@ def atualizar_usuario(id):
 
         cursor.execute(
             """
-            SELECT id, nome, criado_em, avatar_url, bio
+            SELECT id, nome, username, criado_em, avatar_url, bio
             FROM usuarios
             WHERE id = %s
             """,

--- a/index.html
+++ b/index.html
@@ -761,6 +761,15 @@
                 font-size: 0.95em;
             }
 
+            .perfil-username {
+                margin: 6px 0 0 0;
+                color: #ff4757;
+                font-size: 0.9em;
+                font-weight: 800;
+                text-transform: lowercase;
+                letter-spacing: 0.04em;
+            }
+
             .perfil-edicao {
                 max-width: 520px;
                 margin: 18px auto 0 auto;
@@ -1180,6 +1189,7 @@
             <h2>Criar Conta</h2>
 
             <input type="text" id="cadastro-nome" placeholder="Nome">
+            <input type="text" id="cadastro-username" placeholder="@USERNAME">
             <input type="email" id="cadastro-email" placeholder="Email">
             <input type="password" id="cadastro-senha" placeholder="Senha">
 
@@ -1407,7 +1417,9 @@
                 const nomeEl = document.getElementById('usuario-nome');
                 const avatarEl = document.getElementById('usuario-avatar');
 
-                nomeEl.innerText = usuario.nome;
+                nomeEl.innerText = usuario.username
+                    ? `@${usuario.username}`
+                    : usuario.nome;
 
                 if (usuario.avatar_url) {
                     const src = usuario.avatar_url.startsWith('http')
@@ -1444,6 +1456,7 @@
 
         async function cadastrarUsuario() {
             const nome = document.getElementById('cadastro-nome').value.trim();
+            const username = document.getElementById('cadastro-username').value.trim().toLowerCase();
             const email = document.getElementById('cadastro-email').value.trim();
             const senha = document.getElementById('cadastro-senha').value.trim();
 
@@ -1458,7 +1471,7 @@
                     headers: {
                         'Content-Type': 'application/json'
                     },
-                    body: JSON.stringify({ nome, email, senha })
+                    body: JSON.stringify({ nome, username, email, senha })
                 });
 
                 const resposta = await res.json();
@@ -2310,6 +2323,7 @@
                             ${avatarPerfil}
 
                             <h2>${usuario.nome}</h2>
+                            <p class="perfil-username">@${usuario.username}</p>
 
                             <div class="perfil-stats">
                                 <div class="perfil-stat">


### PR DESCRIPTION
## Resumo

- Adiciona `username` único aos usuários
- Valida formato básico do username no cadastro
- Impede cadastro com username duplicado
- Retorna username no login e nas rotas de perfil necessárias
- Exibe `@username` no perfil e no menu do usuário logado
- Prepara a base social para futuras equipes/clubes automotivos

## Testes manuais sugeridos

- Criar usuário com username válido
- Tentar criar usuário com username repetido
- Tentar criar username inválido, com espaço ou acento
- Fazer login novamente após limpar localStorage
- Confirmar se o menu mostra `@username`
- Confirmar se o perfil mostra `@username`
- Conferir se feed, garagem, curtidas, comentários, avatar e seguidores continuam funcionando

Closes #48