### PR TITLE
feat: criar endpoint para buscar equipe do usuário

### DIFF
--- a/app.py
+++ b/app.py
@@ -938,6 +938,82 @@ def listar_carros_usuario(id):
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
     
+@app.route('/usuarios/<int:id>/clube', methods=['GET'])
+def buscar_clube_usuario(id):
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário não encontrado."}), 404
+
+        cursor.execute(
+            """
+            SELECT 
+                c.id,
+                c.nome,
+                c.slug,
+                c.descricao,
+                c.dono_id,
+                c.criado_em,
+                dono.nome AS nome_dono,
+                dono.username AS username_dono,
+                COUNT(DISTINCT todos_membros.id) AS total_membros
+            FROM membros_clube membro_usuario
+            INNER JOIN clubes c ON membro_usuario.clube_id = c.id
+            INNER JOIN usuarios dono ON c.dono_id = dono.id
+            LEFT JOIN membros_clube todos_membros ON c.id = todos_membros.clube_id
+            WHERE membro_usuario.usuario_id = %s
+            GROUP BY 
+                c.id,
+                c.nome,
+                c.slug,
+                c.descricao,
+                c.dono_id,
+                c.criado_em,
+                dono.nome,
+                dono.username
+            LIMIT 1
+            """,
+            (id,)
+        )
+
+        clube = cursor.fetchone()
+
+        if not clube:
+            cursor.close()
+            conexao.close()
+            return jsonify(None), 200
+
+        cursor.execute(
+            """
+            SELECT 
+                u.id,
+                u.nome,
+                u.username,
+                u.avatar_url,
+                m.criado_em
+            FROM membros_clube m
+            INNER JOIN usuarios u ON m.usuario_id = u.id
+            WHERE m.clube_id = %s
+            ORDER BY m.criado_em ASC
+            """,
+            (clube['id'],)
+        )
+
+        membros = cursor.fetchall()
+        clube['membros'] = membros
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify(clube), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+    
 @app.route('/clubes', methods=['POST'])
 def criar_clube():
     dados = request.json

--- a/index.html
+++ b/index.html
@@ -3353,36 +3353,14 @@
             container.innerHTML = '<p>Carregando equipe...</p>';
 
             try {
-                const resposta = await fetch('http://localhost:5000/clubes');
+                const respostaMinhaEquipe = await fetch(`${API_URL}/usuarios/${usuario.id}/clube`);
 
-                if (!resposta.ok) {
-                    container.innerHTML = '<p>Erro ao buscar equipes no servidor.</p>';
+                if (!respostaMinhaEquipe.ok) {
+                    container.innerHTML = '<p>Erro ao carregar sua equipe.</p>';
                     return;
                 }
 
-                const clubes = await resposta.json();
-
-                if (!Array.isArray(clubes)) {
-                    container.innerHTML = '<p>Resposta inesperada ao carregar equipes.</p>';
-                    console.error('Resposta inesperada:', clubes);
-                    return;
-                }
-
-                const clubesDetalhados = [];
-
-                for (const clube of clubes) {
-                    const respostaDetalhe = await fetch(`http://localhost:5000/clubes/${clube.id}`);
-
-                    if (respostaDetalhe.ok) {
-                        const detalhe = await respostaDetalhe.json();
-                        clubesDetalhados.push(detalhe);
-                    }
-                }
-
-                const minhaEquipe = clubesDetalhados.find(clube =>
-                    Array.isArray(clube.membros) &&
-                    clube.membros.some(membro => String(membro.id) === String(usuario.id))
-                );
+                const minhaEquipe = await respostaMinhaEquipe.json();
 
                 if (minhaEquipe) {
                     abrirEquipe(minhaEquipe.id);
@@ -3979,26 +3957,23 @@
             container.innerHTML = '';
 
             try {
-                const res = await fetch('http://localhost:5000/clubes');
-                const clubes = await res.json();
+                const resposta = await fetch(`${API_URL}/usuarios/${usuarioId}/clube`);
 
-                const clubesDetalhados = await Promise.all(
-                    clubes.map(c =>
-                        fetch(`http://localhost:5000/clubes/${c.id}`).then(r => r.json())
-                    )
-                );
+                if (!resposta.ok) {
+                    container.innerHTML = '';
+                    return;
+                }
 
-                const equipe = clubesDetalhados.find(c =>
-                    Array.isArray(c.membros) &&
-                    c.membros.some(m => String(m.id) === String(usuarioId))
-                );
+                const equipe = await resposta.json();
 
                 if (!equipe) {
                     container.innerHTML = '';
                     return;
                 }
 
-                const totalMembros = Array.isArray(equipe.membros) ? equipe.membros.length : 0;
+                const totalMembros = Array.isArray(equipe.membros)
+                    ? equipe.membros.length
+                    : (equipe.total_membros || 0);
 
                 container.innerHTML = `
                     <div class="perfil-equipe-badge" onclick="abrirEquipe(${equipe.id})">
@@ -4013,9 +3988,9 @@
                         <div class="perfil-equipe-acao">Ver →</div>
                     </div>
                 `;
-
-            } catch (err) {
-                console.error('Erro ao carregar equipe do perfil:', err);
+            } catch (erro) {
+                console.error('Erro ao carregar equipe do perfil:', erro);
+                container.innerHTML = '';
             }
         }
 


### PR DESCRIPTION
## Resumo

Esta PR cria um endpoint específico para buscar a equipe/clube de um usuário e atualiza o frontend para usar essa rota.

Antes, o frontend precisava buscar todas as equipes, consultar detalhes de cada uma e filtrar manualmente se o usuário fazia parte de alguma equipe. Agora esse fluxo fica mais direto com `GET /usuarios/<id>/clube`.

## Alterações

- Cria rota `GET /usuarios/<id>/clube`
- Retorna a equipe do usuário quando existir
- Retorna `null` quando o usuário não participa de equipe
- Retorna erro 404 quando o usuário não existe
- Inclui dados básicos da equipe
- Inclui criador da equipe
- Inclui lista de membros
- Atualiza o perfil para usar o novo endpoint
- Atualiza a área `Minha equipe` para usar o novo endpoint

## Banco de dados

Não houve alteração no banco de dados.

O arquivo `garagem_digital.sql` não precisou ser alterado.

Closes #67