### PR TITLE
feat: criar base de pedidos para entrar em equipe

### DIFF
--- a/app.py
+++ b/app.py
@@ -1236,6 +1236,95 @@ def buscar_clube(id):
 
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
+    
+@app.route('/clubes/<int:id>/pedidos', methods=['POST'])
+def pedir_entrada_clube(id):
+    try:
+        dados = request.get_json()
+
+        if not dados:
+            return jsonify({"erro": "Dados não enviados."}), 400
+
+        usuario_id = dados.get('usuario_id')
+
+        if not usuario_id:
+            return jsonify({"erro": "Usuário não informado."}), 400
+
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, usuario_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário não encontrado."}), 404
+
+        cursor.execute(
+            "SELECT id FROM clubes WHERE id = %s",
+            (id,)
+        )
+        clube = cursor.fetchone()
+
+        if not clube:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Equipe não encontrada."}), 404
+
+        cursor.execute(
+            "SELECT id FROM membros_clube WHERE usuario_id = %s LIMIT 1",
+            (usuario_id,)
+        )
+        membro_existente = cursor.fetchone()
+
+        if membro_existente:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Você já participa de uma equipe."}), 400
+
+        cursor.execute(
+            """
+            SELECT id 
+            FROM pedidos_clube 
+            WHERE usuario_id = %s 
+              AND clube_id = %s 
+              AND status = 'pendente'
+            LIMIT 1
+            """,
+            (usuario_id, id)
+        )
+        pedido_existente = cursor.fetchone()
+
+        if pedido_existente:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Você já enviou um pedido para esta equipe."}), 400
+
+        cursor.execute(
+            """
+            INSERT INTO pedidos_clube (usuario_id, clube_id, status)
+            VALUES (%s, %s, 'pendente')
+            """,
+            (usuario_id, id)
+        )
+
+        conexao.commit()
+
+        pedido_id = cursor.lastrowid
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify({
+            "mensagem": "Pedido enviado com sucesso.",
+            "pedido": {
+                "id": pedido_id,
+                "usuario_id": usuario_id,
+                "clube_id": id,
+                "status": "pendente"
+            }
+        }), 201
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
 
 @app.route('/clubes/<int:clube_id>/entrar', methods=['POST'])
 def entrar_clube(clube_id):

--- a/garagem_digital.sql
+++ b/garagem_digital.sql
@@ -7,6 +7,7 @@ COLLATE utf8mb4_general_ci;
 
 USE garagem_digital;
 
+DROP TABLE IF EXISTS pedidos_clube;
 DROP TABLE IF EXISTS membros_clube;
 DROP TABLE IF EXISTS clubes;
 DROP TABLE IF EXISTS seguidores;
@@ -104,6 +105,25 @@ CREATE TABLE clubes (
     PRIMARY KEY (id),
     CONSTRAINT fk_clubes_dono
         FOREIGN KEY (dono_id) REFERENCES usuarios(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE pedidos_clube (
+    id INT NOT NULL AUTO_INCREMENT,
+    usuario_id INT NOT NULL,
+    clube_id INT NOT NULL,
+    status ENUM('pendente', 'aprovado', 'recusado') NOT NULL DEFAULT 'pendente',
+    criado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    atualizado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY pedido_status_unico (usuario_id, clube_id, status),
+    KEY idx_pedidos_usuario (usuario_id),
+    KEY idx_pedidos_clube (clube_id),
+    CONSTRAINT fk_pedidos_usuario
+        FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_pedidos_clube
+        FOREIGN KEY (clube_id) REFERENCES clubes(id)
         ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 

--- a/index.html
+++ b/index.html
@@ -148,6 +148,18 @@
             box-shadow: 0 14px 30px rgba(255, 71, 87, 0.24);
         }
 
+        .btn-pedir-equipe.pedido-enviado {
+            background: rgba(255, 255, 255, 0.06);
+            border-color: rgba(255, 255, 255, 0.14);
+            color: var(--text-muted);
+            box-shadow: none;
+        }
+
+        .btn-pedir-equipe.pedido-enviado:hover {
+            transform: none;
+            box-shadow: none;
+        }
+
         .acoes-garagem {
             display: flex;
             justify-content: center;
@@ -1014,6 +1026,18 @@
                 font-size: 1.15em;
             }
 
+            .btn-pedir-equipe.pedido-enviado {
+                background: rgba(255, 255, 255, 0.06);
+                border-color: rgba(255, 255, 255, 0.14);
+                color: var(--text-muted);
+                box-shadow: none;
+            }
+
+            .btn-pedir-equipe.pedido-enviado:hover {
+                transform: none;
+                box-shadow: none;
+            }
+
             .equipe-membro {
                 align-items: center;
                 border-radius: 16px;
@@ -1196,6 +1220,85 @@
                 min-height: 46px;
             }
         }
+
+            #lista-equipes.equipes-lista {
+                display: grid;
+                gap: 16px;
+                margin-top: 18px;
+            }
+
+            #lista-equipes.equipes-lista .equipe-lista-card {
+                width: 100%;
+                padding: 18px;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 22px;
+                background:
+                    radial-gradient(circle at top right, rgba(255, 71, 87, 0.14), transparent 34%),
+                    linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent),
+                    #151515;
+                box-shadow: 0 14px 32px rgba(0, 0, 0, 0.36);
+                box-sizing: border-box;
+                text-transform: none;
+            }
+
+            #lista-equipes.equipes-lista .equipe-lista-card h4 {
+                margin: 0 0 12px 0;
+                color: #fff;
+                font-size: 1.12em;
+                font-weight: 900;
+                text-transform: uppercase;
+                letter-spacing: -0.2px;
+            }
+
+            #lista-equipes.equipes-lista .equipe-lista-card p {
+                margin: 0 0 16px 0;
+                color: #cfcfcf;
+                line-height: 1.5;
+                font-size: 0.96em;
+                text-transform: none;
+            }
+
+            #lista-equipes.equipes-lista .equipe-lista-meta {
+                display: flex;
+                gap: 8px;
+                flex-wrap: wrap;
+                margin-bottom: 16px;
+                text-transform: none;
+            }
+
+            #lista-equipes.equipes-lista .equipe-lista-meta span {
+                display: inline-flex;
+                align-items: center;
+                gap: 6px;
+                min-height: 30px;
+                padding: 7px 10px;
+                border-radius: var(--radius-pill);
+                border: 1px solid rgba(255, 255, 255, 0.08);
+                background: rgba(255, 255, 255, 0.045);
+                color: var(--text-soft);
+                font-size: 0.82em;
+                font-weight: 800;
+                text-transform: none;
+            }
+
+            #lista-equipes.equipes-lista .btn-pedir-equipe {
+                width: 100%;
+                min-height: 48px;
+                margin: 0;
+                border-radius: var(--radius-pill);
+            }
+
+            #lista-equipes.equipes-lista .btn-pedir-equipe.pedido-enviado {
+                background: rgba(255, 255, 255, 0.06);
+                border-color: rgba(255, 255, 255, 0.14);
+                color: var(--text-muted);
+                box-shadow: none;
+            }
+
+            #lista-equipes.equipes-lista .btn-pedir-equipe.pedido-enviado:hover {
+                transform: none;
+                box-shadow: none;
+            }
 
             .btn-buscar {
                 width: 100%;
@@ -3198,6 +3301,100 @@
             return null;
         }
 
+        function obterUsuarioAtualParaPedidoEquipe() {
+            if (typeof usuarioAtual !== 'undefined' && usuarioAtual && usuarioAtual.id) {
+                return usuarioAtual;
+            }
+
+            if (typeof usuarioLogado !== 'undefined' && usuarioLogado && usuarioLogado.id) {
+                return usuarioLogado;
+            }
+
+            const chavesPossiveis = ['usuario', 'usuarioLogado', 'usuario_atual'];
+
+            for (const chave of chavesPossiveis) {
+                const valor = localStorage.getItem(chave);
+
+                if (!valor) continue;
+
+                try {
+                    const usuario = JSON.parse(valor);
+
+                    if (usuario && usuario.id) {
+                        return usuario;
+                    }
+                } catch (erro) {
+                    console.warn(`Não foi possível ler ${chave} do localStorage`, erro);
+                }
+            }
+
+            return null;
+        }
+
+        async function pedirEntradaEquipe(clubeId, botao) {
+            const usuario = obterUsuarioAtualParaPedidoEquipe();
+
+            if (!usuario || !usuario.id) {
+                alert('Você precisa estar logado para pedir para entrar em uma equipe.');
+                return;
+            }
+
+            const textoOriginal = botao ? botao.textContent : 'Pedir para entrar';
+
+            if (botao) {
+                botao.disabled = true;
+                botao.textContent = 'Enviando...';
+            }
+
+            try {
+                const resposta = await fetch(`${API_URL}/clubes/${clubeId}/pedidos`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        usuario_id: usuario.id
+                    })
+                });
+
+                const dados = await resposta.json();
+
+                if (!resposta.ok) {
+                    const mensagemErro = dados.erro || 'Não foi possível enviar o pedido.';
+
+                    if (botao) {
+                        if (mensagemErro.includes('já enviou')) {
+                            botao.textContent = 'Pedido já enviado';
+                        } else if (mensagemErro.includes('já participa')) {
+                            botao.textContent = 'Você já está em uma equipe';
+                        } else {
+                            botao.textContent = textoOriginal;
+                            botao.disabled = false;
+                        }
+                    }
+
+                    alert(mensagemErro);
+                    return;
+                }
+
+                if (botao) {
+                    botao.textContent = 'Pedido enviado';
+                    botao.classList.add('pedido-enviado');
+                }
+
+                alert(dados.mensagem || 'Pedido enviado com sucesso.');
+            } catch (erro) {
+                console.error('Erro ao pedir entrada na equipe:', erro);
+
+                if (botao) {
+                    botao.disabled = false;
+                    botao.textContent = textoOriginal;
+                }
+
+                alert('Erro ao enviar pedido. Tente novamente.');
+            }
+        }
+
         function abrirMinhaEquipe() {
             const modal = document.getElementById('modal-equipe');
             const container = document.getElementById('conteudo-equipe');
@@ -3362,9 +3559,35 @@
 
                 const minhaEquipe = await respostaMinhaEquipe.json();
 
-                if (minhaEquipe) {
+                if (minhaEquipe && minhaEquipe.id) {
                     abrirEquipe(minhaEquipe.id);
                     return;
+                }
+
+                const respostaClubes = await fetch(`${API_URL}/clubes`);
+
+                if (!respostaClubes.ok) {
+                    container.innerHTML = '<p>Erro ao buscar equipes no servidor.</p>';
+                    return;
+                }
+
+                const clubes = await respostaClubes.json();
+
+                if (!Array.isArray(clubes)) {
+                    container.innerHTML = '<p>Resposta inesperada ao carregar equipes.</p>';
+                    console.error('Resposta inesperada:', clubes);
+                    return;
+                }
+
+                const clubesDetalhados = [];
+
+                for (const clube of clubes) {
+                    const respostaDetalhe = await fetch(`${API_URL}/clubes/${clube.id}`);
+
+                    if (respostaDetalhe.ok) {
+                        const detalhe = await respostaDetalhe.json();
+                        clubesDetalhados.push(detalhe);
+                    }
                 }
 
                 container.innerHTML = `
@@ -3390,6 +3613,9 @@
 
                 const lista = document.getElementById('lista-equipes');
 
+                lista.classList.add('equipes-lista');
+                lista.innerHTML = '';
+
                 if (!clubes.length) {
                     lista.innerHTML = '<p>Nenhuma equipe criada ainda.</p>';
                     return;
@@ -3397,14 +3623,25 @@
 
                 clubes.forEach(clube => {
                     const card = document.createElement('div');
-                    card.className = 'equipe-card';
+                    card.className = 'equipe-lista-card';
+
+                    const totalMembros = clube.total_membros || 0;
 
                     card.innerHTML = `
-                        <h4>${clube.nome}</h4>
-                        <p>${clube.descricao || 'Equipe sem descrição.'}</p>
-                        <div class="equipe-meta">Criado por @${clube.username_dono}</div>
-                        <div class="equipe-meta">Membros: ${clube.total_membros}</div>
-                        <button type="button" class="btn-equipe-secundario" onclick="pedirEntradaEquipe()">
+                        <h4>${textoSeguro(clube.nome)}</h4>
+
+                        <p>${textoSeguro(clube.descricao || 'Equipe sem descrição.')}</p>
+
+                        <div class="equipe-lista-meta">
+                            <span>👤 Criado por @${textoSeguro(clube.username_dono || 'usuario')}</span>
+                            <span>🏁 ${totalMembros} membro${Number(totalMembros) === 1 ? '' : 's'}</span>
+                        </div>
+
+                        <button 
+                            type="button" 
+                            class="btn-principal btn-pedir-equipe" 
+                            onclick="pedirEntradaEquipe(${clube.id}, this)"
+                        >
                             Pedir para entrar
                         </button>
                     `;
@@ -3467,10 +3704,6 @@
             } catch (erro) {
                 alert('Erro ao criar equipe.');
             }
-        }
-
-        function pedirEntradaEquipe() {
-            alert('Sistema de pedidos de entrada será implementado em breve.');
         }
 
         async function abrirPerfil(usuarioId) {


### PR DESCRIPTION
## Resumo

Esta PR cria a base inicial para pedidos de entrada em equipes.

Antes, o botão `Pedir para entrar` era apenas visual. Agora ele envia uma solicitação real para o backend e registra o pedido no banco de dados com status `pendente`.

## Alterações

- Cria tabela `pedidos_clube`
- Adiciona status inicial `pendente`
- Cria endpoint `POST /clubes/<id>/pedidos`
- Impede pedido para equipe inexistente
- Impede pedido de usuário inexistente
- Impede pedido se o usuário já participa de uma equipe
- Impede pedido duplicado pendente para a mesma equipe
- Liga o botão `Pedir para entrar` no frontend
- Mostra feedback visual no botão após o pedido
- Melhora o card de equipes existentes na tela `Minha equipe`

## Banco de dados

Houve alteração no banco de dados.

O arquivo `garagem_digital.sql` foi atualizado com a nova tabela `pedidos_clube`.

## Observação

Esta PR não implementa aprovação ou recusa de pedidos ainda. Isso ficará para uma próxima etapa.

Closes #69