### PR TITLE
feat: aprovar e recusar pedidos de entrada em equipe

### DIFF
--- a/app.py
+++ b/app.py
@@ -1326,6 +1326,253 @@ def pedir_entrada_clube(id):
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
 
+@app.route('/clubes/<int:id>/pedidos', methods=['GET'])
+def listar_pedidos_clube(id):
+    usuario_id = request.args.get('usuario_id')
+
+    if not usuario_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, usuario_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário não encontrado."}), 404
+
+        cursor.execute(
+            "SELECT id, dono_id FROM clubes WHERE id = %s",
+            (id,)
+        )
+        clube = cursor.fetchone()
+
+        if not clube:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Equipe não encontrada."}), 404
+
+        if str(clube['dono_id']) != str(usuario_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Você não tem permissão para ver os pedidos desta equipe."}), 403
+
+        cursor.execute(
+            """
+            SELECT 
+                p.id,
+                p.usuario_id,
+                p.clube_id,
+                p.status,
+                p.criado_em,
+                u.nome,
+                u.username,
+                u.avatar_url
+            FROM pedidos_clube p
+            INNER JOIN usuarios u ON p.usuario_id = u.id
+            WHERE p.clube_id = %s
+              AND p.status = 'pendente'
+            ORDER BY p.criado_em ASC
+            """,
+            (id,)
+        )
+
+        pedidos = cursor.fetchall()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify(pedidos), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
+@app.route('/pedidos-clube/<int:id>/aprovar', methods=['PUT'])
+def aprovar_pedido_clube(id):
+    dados = request.json
+
+    if not dados:
+        return jsonify({"erro": "Dados não enviados."}), 400
+
+    usuario_id = str(dados.get('usuario_id', '')).strip()
+
+    if not usuario_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, usuario_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário não encontrado."}), 404
+
+        cursor.execute(
+            """
+            SELECT 
+                p.id,
+                p.usuario_id,
+                p.clube_id,
+                p.status,
+                c.dono_id
+            FROM pedidos_clube p
+            INNER JOIN clubes c ON p.clube_id = c.id
+            WHERE p.id = %s
+            """,
+            (id,)
+        )
+
+        pedido = cursor.fetchone()
+
+        if not pedido:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Pedido não encontrado."}), 404
+
+        if pedido['status'] != 'pendente':
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Este pedido já foi analisado."}), 400
+
+        if str(pedido['dono_id']) != usuario_id:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Você não tem permissão para aprovar este pedido."}), 403
+
+        cursor.execute(
+            "SELECT id FROM membros_clube WHERE usuario_id = %s LIMIT 1",
+            (pedido['usuario_id'],)
+        )
+        membro_existente = cursor.fetchone()
+
+        if membro_existente:
+            cursor.execute(
+                """
+                UPDATE pedidos_clube
+                SET status = 'recusado'
+                WHERE id = %s
+                """,
+                (id,)
+            )
+
+            conexao.commit()
+
+            cursor.close()
+            conexao.close()
+
+            return jsonify({
+                "erro": "Este usuário já participa de uma equipe. O pedido foi recusado automaticamente."
+            }), 400
+
+        cursor.execute(
+            """
+            INSERT INTO membros_clube (usuario_id, clube_id)
+            VALUES (%s, %s)
+            """,
+            (pedido['usuario_id'], pedido['clube_id'])
+        )
+
+        cursor.execute(
+            """
+            UPDATE pedidos_clube
+            SET status = 'aprovado'
+            WHERE id = %s
+            """,
+            (id,)
+        )
+
+        conexao.commit()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify({"mensagem": "Pedido aprovado com sucesso."}), 200
+
+    except mysql.connector.IntegrityError:
+        try:
+            conexao.rollback()
+            cursor.close()
+            conexao.close()
+        except:
+            pass
+
+        return jsonify({"erro": "Não foi possível aprovar. O usuário já participa de uma equipe."}), 400
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
+@app.route('/pedidos-clube/<int:id>/recusar', methods=['PUT'])
+def recusar_pedido_clube(id):
+    dados = request.json
+
+    if not dados:
+        return jsonify({"erro": "Dados não enviados."}), 400
+
+    usuario_id = str(dados.get('usuario_id', '')).strip()
+
+    if not usuario_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, usuario_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário não encontrado."}), 404
+
+        cursor.execute(
+            """
+            SELECT 
+                p.id,
+                p.status,
+                c.dono_id
+            FROM pedidos_clube p
+            INNER JOIN clubes c ON p.clube_id = c.id
+            WHERE p.id = %s
+            """,
+            (id,)
+        )
+
+        pedido = cursor.fetchone()
+
+        if not pedido:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Pedido não encontrado."}), 404
+
+        if pedido['status'] != 'pendente':
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Este pedido já foi analisado."}), 400
+
+        if str(pedido['dono_id']) != usuario_id:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Você não tem permissão para recusar este pedido."}), 403
+
+        cursor.execute(
+            """
+            UPDATE pedidos_clube
+            SET status = 'recusado'
+            WHERE id = %s
+            """,
+            (id,)
+        )
+
+        conexao.commit()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify({"mensagem": "Pedido recusado com sucesso."}), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
 @app.route('/clubes/<int:clube_id>/entrar', methods=['POST'])
 def entrar_clube(clube_id):
     dados = request.json

--- a/index.html
+++ b/index.html
@@ -792,6 +792,114 @@
             }
         }
 
+        .pedidos-equipe-bloco {
+            margin-top: 18px;
+            padding: 18px;
+            border: 1px solid rgba(255, 71, 87, 0.22);
+            border-radius: var(--radius-lg);
+            background:
+                radial-gradient(circle at top left, rgba(255, 71, 87, 0.11), transparent 34%),
+                linear-gradient(145deg, rgba(255, 255, 255, 0.035), transparent),
+                #111;
+            box-shadow: 0 12px 28px rgba(0, 0, 0, 0.26);
+            text-transform: none;
+        }
+
+        .pedidos-equipe-bloco h3 {
+            margin: 0 0 8px 0;
+            color: #fff;
+            font-size: 1.05em;
+            text-transform: uppercase;
+        }
+
+        .pedidos-equipe-bloco > p {
+            margin: 0 0 14px 0;
+            color: var(--text-muted);
+            font-size: 0.9em;
+            line-height: 1.5;
+            text-transform: none;
+        }
+
+        .pedido-equipe-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 16px;
+            background: rgba(255, 255, 255, 0.035);
+            margin-top: 10px;
+        }
+
+        .pedido-equipe-info {
+            min-width: 0;
+            flex: 1;
+        }
+
+        .pedido-equipe-info strong {
+            display: block;
+            color: #fff;
+            font-size: 0.95em;
+            margin-bottom: 3px;
+        }
+
+        .pedido-equipe-info span {
+            display: block;
+            color: var(--text-muted);
+            font-size: 0.82em;
+            text-transform: none;
+        }
+
+        .pedido-equipe-acoes {
+            display: flex;
+            gap: 8px;
+            flex-shrink: 0;
+        }
+
+        .btn-aprovar-pedido,
+        .btn-recusar-pedido {
+            width: auto;
+            min-height: 38px;
+            margin: 0;
+            padding: 8px 12px;
+            border-radius: var(--radius-pill);
+            font-size: 0.78em;
+            font-weight: 900;
+        }
+
+        .btn-aprovar-pedido {
+            background: rgba(46, 213, 115, 0.12);
+            border-color: rgba(46, 213, 115, 0.45);
+            color: #2ed573;
+        }
+
+        .btn-aprovar-pedido:hover {
+            border-color: #2ed573;
+            box-shadow: 0 10px 22px rgba(46, 213, 115, 0.14);
+        }
+
+        .btn-recusar-pedido {
+            background: rgba(255, 71, 87, 0.08);
+            border-color: rgba(255, 71, 87, 0.38);
+            color: var(--accent);
+        }
+
+        .btn-recusar-pedido:hover {
+            border-color: var(--accent);
+            box-shadow: 0 10px 22px rgba(255, 71, 87, 0.14);
+        }
+
+        .pedidos-equipe-vazio {
+            padding: 12px;
+            border-radius: 14px;
+            background: rgba(255, 255, 255, 0.025);
+            border: 1px dashed rgba(255, 255, 255, 0.1);
+            color: var(--text-muted);
+            font-size: 0.9em;
+            text-transform: none;
+        }        
+
         @media (max-width: 600px) {
             .linha-inputs {
                 flex-direction: column;
@@ -1010,6 +1118,20 @@
 
             .perfil-equipe-acao {
                 display: none;
+            }
+
+            .pedido-equipe-item {
+                align-items: flex-start;
+                flex-direction: column;
+            }
+
+            .pedido-equipe-acoes {
+                width: 100%;
+            }
+
+            .btn-aprovar-pedido,
+            .btn-recusar-pedido {
+                flex: 1;
             }
 
             .perfil-equipe-nome {
@@ -3507,6 +3629,8 @@
                         </div>
                     </div>
 
+                    <div id="pedidos-equipe-container"></div>
+
                     <div class="equipe-garagem-futura">
                         <div class="equipe-garagem-futura-topo">
                             <div class="equipe-garagem-icone">🏎️</div>
@@ -3527,9 +3651,204 @@
                     </div>
                 `;
 
+            const usuario = obterUsuarioAtualParaPedidoEquipe();
+
+            if (usuario && String(usuario.id) === String(equipe.dono_id)) {
+                carregarPedidosEquipe(equipe.id);
+            }
+
             } catch (erro) {
                 console.error('Erro ao abrir equipe:', erro);
                 container.innerHTML = '<p>Erro ao carregar equipe. Verifique se o servidor Flask está rodando.</p>';
+            }
+        }
+
+        async function carregarPedidosEquipe(clubeId) {
+            const container = document.getElementById('pedidos-equipe-container');
+            const usuario = obterUsuarioAtualParaPedidoEquipe();
+
+            if (!container || !usuario || !usuario.id) return;
+
+            container.innerHTML = `
+                <div class="pedidos-equipe-bloco">
+                    <h3>Pedidos pendentes</h3>
+                    <p>Carregando solicitações de entrada...</p>
+                </div>
+            `;
+
+            try {
+                const resposta = await fetch(`${API_URL}/clubes/${clubeId}/pedidos?usuario_id=${usuario.id}`);
+
+                if (!resposta.ok) {
+                    container.innerHTML = '';
+                    return;
+                }
+
+                const pedidos = await resposta.json();
+
+                if (!Array.isArray(pedidos) || pedidos.length === 0) {
+                    container.innerHTML = `
+                        <div class="pedidos-equipe-bloco">
+                            <h3>Pedidos pendentes</h3>
+                            <div class="pedidos-equipe-vazio">
+                                Nenhum pedido pendente no momento.
+                            </div>
+                        </div>
+                    `;
+                    return;
+                }
+
+                const pedidosHtml = pedidos.map(pedido => `
+                    <div class="pedido-equipe-item">
+                        <div class="pedido-equipe-info">
+                            <strong>${textoSeguro(pedido.nome)}</strong>
+                            <span>@${textoSeguro(pedido.username || 'usuario')}</span>
+                        </div>
+
+                        <div class="pedido-equipe-acoes">
+                            <button 
+                                type="button" 
+                                class="btn-aprovar-pedido"
+                                onclick="aprovarPedidoEquipe(${pedido.id}, ${clubeId}, this)"
+                            >
+                                Aprovar
+                            </button>
+
+                            <button 
+                                type="button" 
+                                class="btn-recusar-pedido"
+                                onclick="recusarPedidoEquipe(${pedido.id}, ${clubeId}, this)"
+                            >
+                                Recusar
+                            </button>
+                        </div>
+                    </div>
+                `).join('');
+
+                container.innerHTML = `
+                    <div class="pedidos-equipe-bloco">
+                        <h3>Pedidos pendentes</h3>
+                        <p>Analise quem pode entrar na equipe.</p>
+                        ${pedidosHtml}
+                    </div>
+                `;
+            } catch (erro) {
+                console.error('Erro ao carregar pedidos da equipe:', erro);
+                container.innerHTML = '';
+            }
+        }
+
+        async function aprovarPedidoEquipe(pedidoId, clubeId, botao) {
+            const usuario = obterUsuarioAtualParaPedidoEquipe();
+
+            if (!usuario || !usuario.id) {
+                alert('Você precisa estar logado para aprovar pedidos.');
+                return;
+            }
+
+            if (!confirm('Aprovar este pedido de entrada?')) {
+                return;
+            }
+
+            const textoOriginal = botao ? botao.textContent : 'Aprovar';
+
+            if (botao) {
+                botao.disabled = true;
+                botao.textContent = 'Aprovando...';
+            }
+
+            try {
+                const resposta = await fetch(`${API_URL}/pedidos-clube/${pedidoId}/aprovar`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        usuario_id: usuario.id
+                    })
+                });
+
+                const dados = await resposta.json();
+
+                if (!resposta.ok) {
+                    alert(dados.erro || 'Não foi possível aprovar o pedido.');
+
+                    if (botao) {
+                        botao.disabled = false;
+                        botao.textContent = textoOriginal;
+                    }
+
+                    return;
+                }
+
+                alert(dados.mensagem || 'Pedido aprovado com sucesso.');
+
+                abrirEquipe(clubeId);
+            } catch (erro) {
+                console.error('Erro ao aprovar pedido:', erro);
+                alert('Erro ao aprovar pedido. Tente novamente.');
+
+                if (botao) {
+                    botao.disabled = false;
+                    botao.textContent = textoOriginal;
+                }
+            }
+        }
+
+        async function recusarPedidoEquipe(pedidoId, clubeId, botao) {
+            const usuario = obterUsuarioAtualParaPedidoEquipe();
+
+            if (!usuario || !usuario.id) {
+                alert('Você precisa estar logado para recusar pedidos.');
+                return;
+            }
+
+            if (!confirm('Recusar este pedido de entrada?')) {
+                return;
+            }
+
+            const textoOriginal = botao ? botao.textContent : 'Recusar';
+
+            if (botao) {
+                botao.disabled = true;
+                botao.textContent = 'Recusando...';
+            }
+
+            try {
+                const resposta = await fetch(`${API_URL}/pedidos-clube/${pedidoId}/recusar`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        usuario_id: usuario.id
+                    })
+                });
+
+                const dados = await resposta.json();
+
+                if (!resposta.ok) {
+                    alert(dados.erro || 'Não foi possível recusar o pedido.');
+
+                    if (botao) {
+                        botao.disabled = false;
+                        botao.textContent = textoOriginal;
+                    }
+
+                    return;
+                }
+
+                alert(dados.mensagem || 'Pedido recusado com sucesso.');
+
+                carregarPedidosEquipe(clubeId);
+            } catch (erro) {
+                console.error('Erro ao recusar pedido:', erro);
+                alert('Erro ao recusar pedido. Tente novamente.');
+
+                if (botao) {
+                    botao.disabled = false;
+                    botao.textContent = textoOriginal;
+                }
             }
         }
 


### PR DESCRIPTION
## Resumo

Esta PR permite que o criador de uma equipe visualize, aprove e recuse pedidos pendentes de entrada.

A base de pedidos já existia: usuários sem equipe podiam clicar em `Pedir para entrar` e criar uma solicitação com status `pendente`. Agora o criador da equipe consegue gerenciar esses pedidos diretamente no modal da equipe.

## Alterações

- Cria endpoint para listar pedidos pendentes de uma equipe
- Cria endpoint para aprovar pedido de entrada
- Cria endpoint para recusar pedido de entrada
- Garante que apenas o criador da equipe consiga ver/analisar pedidos
- Ao aprovar:
  - adiciona o usuário em `membros_clube`
  - atualiza o pedido para status `aprovado`
- Ao recusar:
  - atualiza o pedido para status `recusado`
- Impede aprovação se o usuário já participa de outra equipe
- Mostra seção `Pedidos pendentes` no modal da equipe apenas para o criador
- Adiciona botões `Aprovar` e `Recusar`
- Atualiza o modal da equipe após aprovar ou recusar

## Banco de dados

Não houve alteração no banco de dados.

A tabela `pedidos_clube` já existia da etapa anterior.

O arquivo `garagem_digital.sql` não precisou ser alterado nesta PR.

## Testes realizados

- Criador da equipe consegue ver pedidos pendentes
- Usuário que não é criador não vê área de aprovação
- Aprovar pedido adiciona usuário em `membros_clube`
- Aprovar pedido muda status para `aprovado`
- Recusar pedido muda status para `recusado`
- Modal da equipe continua abrindo normalmente
- Lista de membros atualiza depois da aprovação

Closes #71