### PR TITLE
feat: mostrar status do pedido de entrada em equipe

### DIFF
--- a/app.py
+++ b/app.py
@@ -1013,6 +1013,76 @@ def buscar_clube_usuario(id):
 
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
+
+@app.route('/usuarios/<int:id>/pedidos-clube', methods=['GET'])
+def listar_pedidos_clube_usuario(id):
+    status = request.args.get('status', 'pendente')
+
+    status_permitidos = ['pendente', 'aprovado', 'recusado', 'todos']
+
+    if status not in status_permitidos:
+        return jsonify({"erro": "Status inválido."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário não encontrado."}), 404
+
+        sql = """
+            SELECT 
+                p.id,
+                p.usuario_id,
+                p.clube_id,
+                p.status,
+                p.criado_em,
+                c.nome AS nome_clube,
+                c.slug,
+                c.descricao,
+                c.dono_id,
+                dono.username AS username_dono,
+                COUNT(DISTINCT membros.id) AS total_membros
+            FROM pedidos_clube p
+            INNER JOIN clubes c ON p.clube_id = c.id
+            INNER JOIN usuarios dono ON c.dono_id = dono.id
+            LEFT JOIN membros_clube membros ON c.id = membros.clube_id
+            WHERE p.usuario_id = %s
+        """
+
+        valores = [id]
+
+        if status != 'todos':
+            sql += " AND p.status = %s"
+            valores.append(status)
+
+        sql += """
+            GROUP BY 
+                p.id,
+                p.usuario_id,
+                p.clube_id,
+                p.status,
+                p.criado_em,
+                c.nome,
+                c.slug,
+                c.descricao,
+                c.dono_id,
+                dono.username
+            ORDER BY p.criado_em DESC
+        """
+
+        cursor.execute(sql, tuple(valores))
+        pedidos = cursor.fetchall()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify(pedidos), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
     
 @app.route('/clubes', methods=['POST'])
 def criar_clube():

--- a/index.html
+++ b/index.html
@@ -160,6 +160,11 @@
             box-shadow: none;
         }
 
+        .btn-pedir-equipe.pedido-pendente {
+            cursor: not-allowed;
+            opacity: 0.72;
+        }
+
         .acoes-garagem {
             display: flex;
             justify-content: center;
@@ -3453,6 +3458,28 @@
             return null;
         }
 
+        async function carregarPedidosPendentesUsuario(usuarioId) {
+            try {
+                const resposta = await fetch(`${API_URL}/usuarios/${usuarioId}/pedidos-clube?status=pendente`);
+
+                if (!resposta.ok) {
+                    console.warn('Não foi possível carregar pedidos pendentes do usuário.');
+                    return [];
+                }
+
+                const pedidos = await resposta.json();
+
+                if (!Array.isArray(pedidos)) {
+                    return [];
+                }
+
+                return pedidos;
+            } catch (erro) {
+                console.error('Erro ao carregar pedidos pendentes do usuário:', erro);
+                return [];
+            }
+        }
+
         async function pedirEntradaEquipe(clubeId, botao) {
             const usuario = obterUsuarioAtualParaPedidoEquipe();
 
@@ -3486,7 +3513,9 @@
 
                     if (botao) {
                         if (mensagemErro.includes('já enviou')) {
-                            botao.textContent = 'Pedido já enviado';
+                            botao.textContent = 'Pedido pendente';
+                            botao.classList.add('pedido-enviado', 'pedido-pendente');
+                            botao.disabled = true;
                         } else if (mensagemErro.includes('já participa')) {
                             botao.textContent = 'Você já está em uma equipe';
                         } else {
@@ -3500,8 +3529,9 @@
                 }
 
                 if (botao) {
-                    botao.textContent = 'Pedido enviado';
-                    botao.classList.add('pedido-enviado');
+                    botao.textContent = 'Pedido pendente';
+                    botao.classList.add('pedido-enviado', 'pedido-pendente');
+                    botao.disabled = true;
                 }
 
                 alert(dados.mensagem || 'Pedido enviado com sucesso.');
@@ -3940,11 +3970,38 @@
                     return;
                 }
 
+                const pedidosPendentes = await carregarPedidosPendentesUsuario(usuario.id);
+                const clubesComPedidoPendente = new Set(
+                    pedidosPendentes.map(pedido => String(pedido.clube_id))
+                );
+
                 clubes.forEach(clube => {
                     const card = document.createElement('div');
                     card.className = 'equipe-lista-card';
 
                     const totalMembros = clube.total_membros || 0;
+
+                    const temPedidoPendente = clubesComPedidoPendente.has(String(clube.id));
+
+                    const botaoPedidoHtml = temPedidoPendente
+                        ? `
+                            <button 
+                                type="button" 
+                                class="btn-principal btn-pedir-equipe pedido-enviado pedido-pendente" 
+                                disabled
+                            >
+                                Pedido pendente
+                            </button>
+                        `
+                        : `
+                            <button 
+                                type="button" 
+                                class="btn-principal btn-pedir-equipe" 
+                                onclick="pedirEntradaEquipe(${clube.id}, this)"
+                            >
+                                Pedir para entrar
+                            </button>
+                        `;
 
                     card.innerHTML = `
                         <h4>${textoSeguro(clube.nome)}</h4>
@@ -3956,13 +4013,7 @@
                             <span>🏁 ${totalMembros} membro${Number(totalMembros) === 1 ? '' : 's'}</span>
                         </div>
 
-                        <button 
-                            type="button" 
-                            class="btn-principal btn-pedir-equipe" 
-                            onclick="pedirEntradaEquipe(${clube.id}, this)"
-                        >
-                            Pedir para entrar
-                        </button>
+                        ${botaoPedidoHtml}
                     `;
 
                     lista.appendChild(card);


### PR DESCRIPTION
## Resumo

Esta PR melhora a experiência do usuário ao pedir para entrar em uma equipe.

Agora, quando o usuário já possui um pedido pendente para uma equipe, a interface mostra o estado `Pedido pendente` e desabilita o botão, em vez de deixar o botão `Pedir para entrar` ativo até o backend bloquear a duplicação.

## Alterações

- Cria endpoint para listar pedidos de equipe de um usuário
- Permite filtrar pedidos por status
- Busca pedidos pendentes do usuário no frontend
- Identifica equipes onde já existe pedido pendente
- Troca o botão `Pedir para entrar` por `Pedido pendente`
- Desabilita o botão quando já houver solicitação pendente
- Atualiza o botão para `Pedido pendente` logo após o envio do pedido
- Mantém o fluxo atual de aprovação e recusa de pedidos

## Banco de dados

Não houve alteração no banco de dados.

A tabela `pedidos_clube` já existia da etapa anterior.

O arquivo `garagem_digital.sql` não precisou ser alterado nesta PR.

## Testes realizados

- Usuário sem equipe consegue ver equipes disponíveis
- Usuário sem pedido pendente vê botão `Pedir para entrar`
- Ao pedir entrada, botão muda para `Pedido pendente`
- Ao recarregar a tela, pedido pendente continua aparecendo corretamente
- Botão fica desabilitado quando já existe pedido pendente
- Criador continua conseguindo aprovar e recusar pedidos
- Usuário com equipe continua abrindo o modal da própria equipe normalmente

Closes #73