### PR TITLE
fix: corrigir erro ao recusar pedido repetido de equipe

### DIFF
--- a/app.py
+++ b/app.py
@@ -1598,6 +1598,8 @@ def recusar_pedido_clube(id):
             """
             SELECT 
                 p.id,
+                p.usuario_id,
+                p.clube_id,
                 p.status,
                 c.dono_id
             FROM pedidos_clube p
@@ -1623,6 +1625,17 @@ def recusar_pedido_clube(id):
             cursor.close()
             conexao.close()
             return jsonify({"erro": "Você não tem permissão para recusar este pedido."}), 403
+        
+        cursor.execute(
+            """
+            DELETE FROM pedidos_clube
+            WHERE usuario_id = %s
+            AND clube_id = %s
+            AND status = 'recusado'
+            AND id <> %s
+            """,
+            (pedido['usuario_id'], pedido['clube_id'], id)
+        )
 
         cursor.execute(
             """


### PR DESCRIPTION
## Resumo

Esta PR corrige um erro ao recusar pedidos repetidos de entrada em equipe.

Antes, se um usuário já tivesse um pedido recusado anteriormente para a mesma equipe e enviasse um novo pedido pendente, ao recusar novamente o backend podia retornar erro bruto do banco:

`Duplicate entry ... for key pedido_status_unico`

## Alterações

- Ajusta a rota de recusa de pedido de equipe
- Inclui `usuario_id` e `clube_id` na consulta do pedido
- Remove pedido recusado antigo do mesmo usuário/equipe antes de recusar o pedido atual
- Evita erro de duplicidade no índice `pedido_status_unico`
- Mantém apenas o registro recusado mais recente para aquele usuário/equipe
- Mantém o fluxo atual de pedidos funcionando

## Banco de dados

Não houve alteração estrutural no banco de dados.

O arquivo `garagem_digital.sql` não precisou ser alterado nesta PR.

## Testes realizados

- Pedido repetido foi recusado com sucesso
- Erro bruto de duplicidade não apareceu mais
- Pedido pendente deixou de aparecer após recusa
- Fluxo de pedidos continua funcionando

Closes #76