### PR TITLE
refactor: substituir alerts de comentários por feedback visual

### DIFF
--- a/script.js
+++ b/script.js
@@ -890,7 +890,7 @@
             const usuario = getUsuarioLogado();
 
             if (!usuario) {
-                alert("Faça login para comentar.");
+                mostrarMensagem("Faça login para comentar.", "aviso");
                 return;
             }
 
@@ -898,7 +898,7 @@
             const texto = input.value.trim();
 
             if (!texto) {
-                alert("Digite um comentário.");
+                mostrarMensagem("Digite um comentário.", "aviso");
                 return;
             }
 
@@ -920,12 +920,12 @@
                     carregarGaragem();
                 } else {
                     const erro = await res.json();
-                    alert(erro.erro || "Erro ao comentar.");
+                    mostrarMensagem(erro.erro || "Erro ao comentar.", "erro");
                 }
 
             } catch (error) {
                 console.error(error);
-                alert("Erro de conexão.");
+                mostrarMensagem("Erro de conexão.", "erro");
             }
         }
 
@@ -933,7 +933,7 @@
             const usuario = getUsuarioLogado();
 
             if (!usuario) {
-                alert("Você precisa estar logado para remover um comentário.");
+                mostrarMensagem("Você precisa estar logado para remover um comentário.", "aviso");
                 return;
             }
 
@@ -960,12 +960,12 @@
                     carregarComentarios(carroId);
                     carregarGaragem();
                 } else {
-                    alert(resposta.erro || "Erro ao remover comentário.");
+                    mostrarMensagem(resposta.erro || "Erro ao remover comentário.", "erro");
                 }
 
             } catch (error) {
                 console.error(error);
-                alert("Erro de conexão.");
+                mostrarMensagem("Erro de conexão.", "erro");
             }
         }
 


### PR DESCRIPTION
Closes #95 

## Resumo

Substitui os `alert()` da área de comentários pelo sistema de feedback visual global já existente no projeto.

## Alterações

- Troca alerta de falta de login ao comentar por feedback visual
- Troca alerta de comentário vazio por feedback visual
- Troca mensagens de erro ao comentar por feedback visual
- Troca alerta de falta de login ao remover comentário por feedback visual
- Troca mensagens de erro ao remover comentário por feedback visual
- Mantém o `confirm()` de remoção de comentário como está

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Comentar sem estar logado
- [ ] Comentar com texto vazio
- [ ] Comentar normalmente
- [ ] Remover comentário cancelando no confirm
- [ ] Remover comentário confirmando no confirm
- [ ] Feedback visual apareceu corretamente
- [ ] Nenhum alert nativo apareceu nessas ações
- [ ] O confirm de remoção continuou funcionando
- [ ] Contador de comentários continuou atualizando