### PR TITLE
refactor: substituir alerts de curtidas por feedback visual

### DIFF
--- a/script.js
+++ b/script.js
@@ -466,7 +466,7 @@
                 });
 
             } catch (error) {
-                alert("Erro ao carregar a garagem. Verifique se o Flask está rodando.");
+                mostrarMensagem("Erro ao carregar a garagem. Verifique se o Flask está rodando.", "erro");
                 console.error(error);
             }
         }
@@ -475,7 +475,7 @@
             const usuario = getUsuarioLogado();
 
             if (!usuario) {
-                alert("Faça login para curtir um projeto.");
+                mostrarMensagem("Faça login para curtir um projeto.", "aviso");
                 return;
             }
 
@@ -499,11 +499,11 @@
                 if (res.ok) {
                     carregarGaragem();
                 } else {
-                    alert("Erro: " + (resposta.erro || "Não foi possível atualizar a curtida."));
+                    mostrarMensagem("Erro: " + (resposta.erro || "Não foi possível atualizar a curtida."), "erro");
                 }
 
             } catch (error) {
-                alert("Erro de conexão com o servidor.");
+                mostrarMensagem("Erro de conexão com o servidor.", "erro");
                 console.error(error);
             }
         }


### PR DESCRIPTION
Closes #97 

## Resumo

Substitui os `alert()` da área de curtidas e carregamento da garagem pelo sistema de feedback visual global já existente no projeto.

## Alterações

- Troca alerta de erro ao carregar a garagem por feedback visual
- Troca alerta de falta de login ao curtir projeto por feedback visual
- Troca mensagem de erro ao atualizar curtida por feedback visual
- Troca mensagem de erro de conexão ao curtir por feedback visual

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Curtir projeto sem estar logado
- [ ] Curtir projeto logado
- [ ] Descurtir projeto logado
- [ ] Feedback visual apareceu corretamente
- [ ] Nenhum alert nativo apareceu nessas ações
- [ ] Contador de curtidas continuou atualizando
- [ ] Animação da curtida continuou funcionando
- [ ] Comentários continuaram funcionando