### PR TITLE
refactor: criar modal visual para confirmações de exclusão

### DIFF
--- a/script.js
+++ b/script.js
@@ -102,6 +102,85 @@
             setTimeout(remover, duracao);
         }
 
+        function confirmarAcao({
+            titulo = "Confirmar ação",
+            mensagem = "Tem certeza que deseja continuar?",
+            textoConfirmar = "Confirmar",
+            textoCancelar = "Cancelar"
+        } = {}) {
+            return new Promise((resolve) => {
+                const modalExistente = document.querySelector('.confirmacao-overlay');
+
+                if (modalExistente) {
+                    modalExistente.remove();
+                }
+
+                const overlay = document.createElement('div');
+                overlay.className = 'confirmacao-overlay';
+
+                overlay.innerHTML = `
+                    <div class="confirmacao-card">
+                        <div class="confirmacao-icone">!</div>
+
+                        <h3>${textoFeedbackSeguro(titulo)}</h3>
+                        <p>${textoFeedbackSeguro(mensagem)}</p>
+
+                        <div class="confirmacao-acoes">
+                            <button type="button" class="btn-confirmacao-cancelar">
+                                ${textoFeedbackSeguro(textoCancelar)}
+                            </button>
+
+                            <button type="button" class="btn-confirmacao-confirmar">
+                                ${textoFeedbackSeguro(textoConfirmar)}
+                            </button>
+                        </div>
+                    </div>
+                `;
+
+                document.body.appendChild(overlay);
+
+                let fechado = false;
+
+                const fechar = (resultado) => {
+                    if (fechado) {
+                        return;
+                    }
+
+                    fechado = true;
+                    document.removeEventListener('keydown', fecharComEsc);
+
+                    overlay.classList.add('saindo');
+
+                    setTimeout(() => {
+                        overlay.remove();
+                        resolve(resultado);
+                    }, 180);
+                };
+
+                function fecharComEsc(event) {
+                    if (event.key === 'Escape') {
+                        fechar(false);
+                    }
+                }
+
+                overlay.querySelector('.btn-confirmacao-cancelar').addEventListener('click', () => {
+                    fechar(false);
+                });
+
+                overlay.querySelector('.btn-confirmacao-confirmar').addEventListener('click', () => {
+                    fechar(true);
+                });
+
+                overlay.addEventListener('click', (event) => {
+                    if (event.target === overlay) {
+                        fechar(false);
+                    }
+                });
+
+                document.addEventListener('keydown', fecharComEsc);
+            });
+        }
+
         function formatarTempoRelativo(dataTexto) {
             if (!dataTexto) {
                 return "";
@@ -876,7 +955,12 @@
                 return;
             }
 
-            const confirmar = confirm("Tem certeza que deseja remover este projeto?");
+            const confirmar = await confirmarAcao({
+                titulo: "Remover projeto?",
+                mensagem: "Essa ação não pode ser desfeita. O projeto será removido da garagem.",
+                textoConfirmar: "Remover projeto",
+                textoCancelar: "Cancelar"
+            });
 
             if (!confirmar) {
                 return;
@@ -1025,7 +1109,12 @@
                 return;
             }
 
-            const confirmar = confirm("Remover este comentário?");
+            const confirmar = await confirmarAcao({
+                titulo: "Remover comentário?",
+                mensagem: "Esse comentário será removido permanentemente.",
+                textoConfirmar: "Remover comentário",
+                textoCancelar: "Cancelar"
+            });
 
             if (!confirmar) {
                 return;

--- a/style.css
+++ b/style.css
@@ -993,6 +993,107 @@
             transform: none;
         }
 
+        .confirmacao-overlay {
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 18px;
+            background: rgba(0, 0, 0, 0.72);
+            backdrop-filter: blur(8px);
+            animation: confirmacaoEntrada 0.18s ease;
+        }
+
+        .confirmacao-overlay.saindo {
+            animation: confirmacaoSaida 0.18s ease forwards;
+        }
+
+        .confirmacao-card {
+            width: min(420px, 100%);
+            padding: 24px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 22px;
+            background:
+                radial-gradient(circle at top left, rgba(255, 71, 87, 0.16), transparent 36%),
+                linear-gradient(145deg, #141414, #080808);
+            box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
+            text-align: left;
+        }
+
+        .confirmacao-icone {
+            width: 38px;
+            height: 38px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 16px;
+            border-radius: 50%;
+            background: rgba(255, 71, 87, 0.16);
+            color: #ff6b7a;
+            font-weight: 900;
+        }
+
+        .confirmacao-card h3 {
+            margin: 0 0 8px;
+            color: #fff;
+            font-size: 1.25rem;
+        }
+
+        .confirmacao-card p {
+            margin: 0;
+            color: #aaa;
+            line-height: 1.5;
+        }
+
+        .confirmacao-acoes {
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+            margin-top: 22px;
+        }
+
+        .btn-confirmacao-cancelar,
+        .btn-confirmacao-confirmar {
+            width: auto;
+            min-width: 110px;
+            margin-top: 0;
+            padding: 11px 15px;
+            border-radius: 999px;
+        }
+
+        .btn-confirmacao-cancelar {
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.06);
+            color: #ddd;
+        }
+
+        .btn-confirmacao-confirmar {
+            background: linear-gradient(135deg, #ff4757, #ff6b7a);
+            color: #fff;
+        }
+
+        @keyframes confirmacaoEntrada {
+            from {
+                opacity: 0;
+            }
+
+            to {
+                opacity: 1;
+            }
+        }
+
+        @keyframes confirmacaoSaida {
+            from {
+                opacity: 1;
+            }
+
+            to {
+                opacity: 0;
+            }
+        }
+
         @keyframes feedbackEntrando {
             from {
                 opacity: 0;


### PR DESCRIPTION
closes #101 

## Resumo

Cria um modal visual reutilizável para confirmações de exclusão, substituindo os `confirm()` nativos do navegador.

## Alterações

- Cria função `confirmarAcao()` em `script.js`
- Substitui confirmação de remoção de projeto
- Substitui confirmação de remoção de comentário
- Adiciona estilos do modal de confirmação em `style.css`
- Permite cancelar clicando fora do modal
- Permite cancelar usando a tecla ESC

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Remover projeto e cancelar
- [ ] Remover projeto e confirmar
- [ ] Remover comentário e cancelar
- [ ] Remover comentário e confirmar
- [ ] Clicar fora do modal cancela a ação
- [ ] Tecla ESC cancela a ação
- [ ] Feedback visual aparece depois da exclusão
- [ ] `grep -n "confirm(" script.js` não retorna confirmações nativas
- [ ] `grep -n "alert(" script.js` mostra apenas o fallback de `mostrarMensagem()`