### PR TITLE
refactor: criar modal visual para confirmações de pedidos de equipe

### DIFF
--- a/script.js
+++ b/script.js
@@ -181,6 +181,85 @@
             });
         }
 
+        function confirmarAcao({
+            titulo = "Confirmar ação",
+            mensagem = "Tem certeza que deseja continuar?",
+            textoConfirmar = "Confirmar",
+            textoCancelar = "Cancelar"
+        } = {}) {
+            return new Promise((resolve) => {
+                const modalExistente = document.querySelector('.confirmacao-overlay');
+
+                if (modalExistente) {
+                    modalExistente.remove();
+                }
+
+                const overlay = document.createElement('div');
+                overlay.className = 'confirmacao-overlay';
+
+                overlay.innerHTML = `
+                    <div class="confirmacao-card">
+                        <div class="confirmacao-icone">!</div>
+
+                        <h3>${textoFeedbackSeguro(titulo)}</h3>
+                        <p>${textoFeedbackSeguro(mensagem)}</p>
+
+                        <div class="confirmacao-acoes">
+                            <button type="button" class="btn-confirmacao-cancelar">
+                                ${textoFeedbackSeguro(textoCancelar)}
+                            </button>
+
+                            <button type="button" class="btn-confirmacao-confirmar">
+                                ${textoFeedbackSeguro(textoConfirmar)}
+                            </button>
+                        </div>
+                    </div>
+                `;
+
+                document.body.appendChild(overlay);
+
+                let fechado = false;
+
+                const fechar = (resultado) => {
+                    if (fechado) {
+                        return;
+                    }
+
+                    fechado = true;
+                    document.removeEventListener('keydown', fecharComEsc);
+
+                    overlay.classList.add('saindo');
+
+                    setTimeout(() => {
+                        overlay.remove();
+                        resolve(resultado);
+                    }, 180);
+                };
+
+                function fecharComEsc(event) {
+                    if (event.key === 'Escape') {
+                        fechar(false);
+                    }
+                }
+
+                overlay.querySelector('.btn-confirmacao-cancelar').addEventListener('click', () => {
+                    fechar(false);
+                });
+
+                overlay.querySelector('.btn-confirmacao-confirmar').addEventListener('click', () => {
+                    fechar(true);
+                });
+
+                overlay.addEventListener('click', (event) => {
+                    if (event.target === overlay) {
+                        fechar(false);
+                    }
+                });
+
+                document.addEventListener('keydown', fecharComEsc);
+            });
+        }
+
         function formatarTempoRelativo(dataTexto) {
             if (!dataTexto) {
                 return "";
@@ -1513,7 +1592,14 @@
                 return;
             }
 
-            if (!confirm('Aprovar este pedido de entrada?')) {
+            const confirmar = await confirmarAcao({
+                titulo: "Aprovar pedido?",
+                mensagem: "Este usuário será adicionado à equipe.",
+                textoConfirmar: "Aprovar",
+                textoCancelar: "Cancelar"
+            });
+
+            if (!confirmar) {
                 return;
             }
 
@@ -1570,7 +1656,14 @@
                 return;
             }
 
-            if (!confirm('Recusar este pedido de entrada?')) {
+            const confirmar = await confirmarAcao({
+                titulo: "Recusar pedido?",
+                mensagem: "O pedido de entrada será recusado.",
+                textoConfirmar: "Recusar",
+                textoCancelar: "Cancelar"
+            });
+
+            if (!confirmar) {
                 return;
             }
 


### PR DESCRIPTION
closes #103 

## Resumo

Cria um modal visual reutilizável para confirmações de aprovação e recusa de pedidos de entrada em equipe, substituindo os `confirm()` nativos do navegador.

## Alterações

- Cria função `confirmarAcao()` em `script.js`
- Substitui confirmação nativa ao aprovar pedido de entrada
- Substitui confirmação nativa ao recusar pedido de entrada
-  Reaproveita os estilos já existentes do modal de confirmação
- Permite cancelar clicando fora do modal
- Permite cancelar usando a tecla ESC

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Aprovar pedido e cancelar
- [ ] Aprovar pedido e confirmar
- [ ] Recusar pedido e cancelar
- [ ] Recusar pedido e confirmar
- [ ] Clicar fora do modal cancela a ação
- [ ] Tecla ESC cancela a ação
- [ ] Feedback visual aparece depois da ação
- [ ] `grep -n "confirm(" script.js` não retorna confirmações nativas
- [ ] `grep -n "alert(" script.js` mostra apenas o fallback de `mostrarMensagem()`