### PR TITLE
feat: permitir cancelar pedido pendente de equipe

### DIFF
--- a/app.py
+++ b/app.py
@@ -1396,6 +1396,65 @@ def pedir_entrada_clube(id):
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
 
+@app.route('/clubes/<int:id>/pedidos', methods=['DELETE'])
+def cancelar_pedido_clube(id):
+    dados = request.json or {}
+    usuario_id = str(dados.get('usuario_id', '')).strip()
+
+    if not usuario_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, usuario_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário inválido."}), 403
+
+        cursor.execute("SELECT id FROM clubes WHERE id = %s", (id,))
+        clube = cursor.fetchone()
+
+        if not clube:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Equipe não encontrada."}), 404
+
+        cursor.execute(
+            """
+            SELECT id
+            FROM pedidos_clube
+            WHERE usuario_id = %s
+              AND clube_id = %s
+              AND status = 'pendente'
+            LIMIT 1
+            """,
+            (usuario_id, id)
+        )
+
+        pedido = cursor.fetchone()
+
+        if not pedido:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Pedido pendente não encontrado."}), 404
+
+        cursor.execute(
+            "DELETE FROM pedidos_clube WHERE id = %s",
+            (pedido['id'],)
+        )
+
+        conexao.commit()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify({"mensagem": "Pedido cancelado com sucesso."}), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
 @app.route('/clubes/<int:id>/pedidos', methods=['GET'])
 def listar_pedidos_clube(id):
     usuario_id = request.args.get('usuario_id')

--- a/script.js
+++ b/script.js
@@ -1345,9 +1345,15 @@
                 }
 
                 if (botao) {
-                    botao.textContent = 'Pedido pendente';
-                    botao.classList.add('pedido-enviado', 'pedido-pendente');
-                    botao.disabled = true;
+                    botao.classList.remove('pedido-enviado', 'pedido-pendente');
+                    botao.classList.add('btn-principal', 'btn-pedir-equipe', 'btn-pedido-pendente');
+                    botao.disabled = false;
+                    botao.textContent = 'Cancelar pedido';
+
+                    botao.onclick = (event) => {
+                        event.stopPropagation();
+                        cancelarPedidoEquipe(clubeId, botao);
+                    };
                 }
 
                 mostrarMensagem(dados.mensagem || 'Pedido enviado com sucesso.', 'sucesso');
@@ -1360,6 +1366,80 @@
                 }
 
                 mostrarMensagem('Erro ao enviar pedido. Tente novamente.', 'erro');
+            }
+        }
+
+        async function cancelarPedidoEquipe(clubeId, botao = null) {
+            const usuario = getUsuarioLogado();
+
+            if (!usuario || !usuario.id) {
+                mostrarMensagem("Faça login para cancelar o pedido.", "aviso");
+                return;
+            }
+
+            const confirmar = await confirmarAcao({
+                titulo: "Cancelar pedido?",
+                mensagem: "Seu pedido pendente para entrar nesta equipe será cancelado.",
+                textoConfirmar: "Cancelar pedido",
+                textoCancelar: "Voltar"
+            });
+
+            if (!confirmar) {
+                return;
+            }
+
+            const textoOriginal = botao ? botao.textContent : "Cancelar pedido";
+
+            if (botao) {
+                botao.disabled = true;
+                botao.textContent = "Cancelando...";
+            }
+
+            try {
+                const resposta = await fetch(`${API_URL}/clubes/${clubeId}/pedidos`, {
+                    method: "DELETE",
+                    headers: {
+                        "Content-Type": "application/json"
+                    },
+                    body: JSON.stringify({
+                        usuario_id: usuario.id
+                    })
+                });
+
+                const dados = await resposta.json();
+
+                if (!resposta.ok) {
+                    mostrarMensagem(dados.erro || "Erro ao cancelar pedido.", "erro");
+
+                    if (botao) {
+                        botao.disabled = false;
+                        botao.textContent = textoOriginal;
+                    }
+
+                    return;
+                }
+
+                mostrarMensagem(dados.mensagem || "Pedido cancelado com sucesso.", "sucesso");
+
+                if (botao) {
+                    botao.classList.remove('btn-pedido-pendente', 'pedido-pendente', 'pedido-enviado');
+                    botao.classList.add('btn-principal', 'btn-pedir-equipe');
+                    botao.disabled = false;
+                    botao.textContent = "Pedir para entrar";
+
+                    botao.onclick = (event) => {
+                        event.stopPropagation();
+                        pedirEntradaEquipe(clubeId, botao);
+                    };
+                }
+            } catch (erro) {
+                console.error("Erro ao cancelar pedido:", erro);
+                mostrarMensagem("Erro de conexão ao cancelar pedido.", "erro");
+
+                if (botao) {
+                    botao.disabled = false;
+                    botao.textContent = textoOriginal;
+                }
             }
         }
 
@@ -1815,19 +1895,19 @@
 
                     const botaoPedidoHtml = temPedidoPendente
                         ? `
-                            <button 
-                                type="button" 
-                                class="btn-principal btn-pedir-equipe pedido-enviado pedido-pendente" 
-                                disabled
+                            <button
+                                type="button"
+                                class="btn-principal btn-pedir-equipe btn-pedido-pendente"
+                                onclick="event.stopPropagation(); cancelarPedidoEquipe(${clube.id}, this)"
                             >
-                                Pedido pendente
+                                Cancelar pedido
                             </button>
                         `
                         : `
                             <button 
                                 type="button" 
                                 class="btn-principal btn-pedir-equipe" 
-                                onclick="pedirEntradaEquipe(${clube.id}, this)"
+                                onclick="event.stopPropagation(); pedirEntradaEquipe(${clube.id}, this)"
                             >
                                 Pedir para entrar
                             </button>

--- a/style.css
+++ b/style.css
@@ -158,6 +158,16 @@
             opacity: 0.72;
         }
 
+        .btn-pedido-pendente {
+            background: rgba(255, 193, 7, 0.12);
+            border: 1px solid rgba(255, 193, 7, 0.35);
+            color: #ffd166;
+        }
+
+        .btn-pedido-pendente:hover {
+            background: rgba(255, 193, 7, 0.18);
+        }
+
         .acoes-garagem {
             display: flex;
             justify-content: center;


### PR DESCRIPTION
closes #107 

## Resumo

Permite que o usuário cancele um pedido pendente de entrada em equipe.

## Alterações

- Cria endpoint `DELETE /clubes/<id>/pedidos`
- Remove o pedido pendente do usuário para a equipe
- Adiciona função `cancelarPedidoEquipe()` no frontend
- Usa o modal visual `confirmarAcao()` antes de cancelar
- Atualiza o botão na própria tela após pedir entrada ou cancelar pedido
- Impede que o clique no botão abra os detalhes da equipe
- Mantém o visual correto do botão ao alternar entre `Pedir para entrar` e `Cancelar pedido`

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Pedi entrada em uma equipe
- [ ] O botão mudou para `Cancelar pedido` imediatamente
- [ ] Cancelei a ação no modal visual
- [ ] Confirmei o cancelamento no modal visual
- [ ] O botão voltou para `Pedir para entrar`
- [ ] Cancelei pedido após sair e voltar para a tela
- [ ] O botão manteve o visual correto após cancelar
- [ ] Clicar no botão não abriu os detalhes da equipe
- [ ] Consegui pedir entrada novamente após cancelar
- [ ] Rodei `python -m py_compile app.py`
- [ ] Rodei `node --check script.js`
- [ ] `grep -n "confirm(" script.js` não retornou confirmações nativas
- [ ] `grep -n "alert(" script.js` mostra apenas o fallback de `mostrarMensagem()`