### PR TITLE
feat: exibir projetos dos membros na garagem da equipe

### DIFF
--- a/app.py
+++ b/app.py
@@ -1306,6 +1306,80 @@ def buscar_clube(id):
 
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
+
+@app.route('/clubes/<int:id>/carros', methods=['GET'])
+def listar_carros_clube(id):
+    usuario_id = request.args.get('usuario_id', '')
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        cursor.execute("SELECT id FROM clubes WHERE id = %s", (id,))
+        clube = cursor.fetchone()
+
+        if not clube:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Equipe não encontrada."}), 404
+
+        cursor.execute(
+            """
+            SELECT
+                c.id,
+                c.usuario_id,
+                c.nome_dono,
+                c.modelo,
+                c.ano,
+                c.cor,
+                c.placa,
+                c.tipo_suspensao,
+                c.aro_roda,
+                c.foto_url,
+                c.historia,
+                u.nome AS nome_usuario,
+                u.username AS username_usuario,
+                COUNT(DISTINCT cur.id) AS total_curtidas,
+                COUNT(DISTINCT com.id) AS total_comentarios,
+                CASE
+                    WHEN SUM(CASE WHEN cur.usuario_id = %s THEN 1 ELSE 0 END) > 0
+                    THEN 1
+                    ELSE 0
+                END AS curtido_pelo_usuario
+            FROM carros c
+            INNER JOIN membros_clube mc ON c.usuario_id = mc.usuario_id
+            INNER JOIN usuarios u ON c.usuario_id = u.id
+            LEFT JOIN curtidas cur ON c.id = cur.carro_id
+            LEFT JOIN comentarios com ON c.id = com.carro_id
+            WHERE mc.clube_id = %s
+            GROUP BY
+                c.id,
+                c.usuario_id,
+                c.nome_dono,
+                c.modelo,
+                c.ano,
+                c.cor,
+                c.placa,
+                c.tipo_suspensao,
+                c.aro_roda,
+                c.foto_url,
+                c.historia,
+                u.nome,
+                u.username
+            ORDER BY c.id DESC
+            """,
+            (usuario_id if usuario_id else 0, id)
+        )
+
+        carros = cursor.fetchall()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify(carros), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
     
 @app.route('/clubes/<int:id>/pedidos', methods=['POST'])
 def pedir_entrada_clube(id):

--- a/script.js
+++ b/script.js
@@ -1478,22 +1478,20 @@
 
                     <div id="pedidos-equipe-container"></div>
 
-                    <div class="equipe-garagem-futura">
+                    <div class="equipe-garagem-futura garagem-equipe-bloco">
                         <div class="equipe-garagem-futura-topo">
                             <div class="equipe-garagem-icone">🏎️</div>
 
                             <div class="equipe-garagem-texto">
                                 <h3>Garagem da equipe</h3>
-                                <p>Em breve, os projetos dos membros poderão aparecer juntos aqui como uma garagem coletiva.</p>
+                                <p>Projetos cadastrados pelos membros da equipe.</p>
                             </div>
                         </div>
 
-                        <div class="equipe-garagem-status">Em breve</div>
-
-                        <div class="equipe-garagem-preview">
-                            <div class="equipe-garagem-preview-item"></div>
-                            <div class="equipe-garagem-preview-item"></div>
-                            <div class="equipe-garagem-preview-item"></div>
+                        <div id="garagem-equipe-lista" class="garagem-equipe-lista">
+                            <p class="garagem-equipe-vazio">
+                                Carregando projetos da equipe...
+                            </p>
                         </div>
                     </div>
                 `;
@@ -1504,9 +1502,100 @@
                 carregarPedidosEquipe(equipe.id);
             }
 
+            carregarGaragemEquipe(equipe.id);
+
             } catch (erro) {
                 console.error('Erro ao abrir equipe:', erro);
                 container.innerHTML = '<p>Erro ao carregar equipe. Verifique se o servidor Flask está rodando.</p>';
+            }
+        }
+
+        async function carregarGaragemEquipe(clubeId) {
+            const container = document.getElementById('garagem-equipe-lista');
+
+            if (!container) {
+                return;
+            }
+
+            container.innerHTML = `
+                <p class="garagem-equipe-vazio">
+                    Carregando projetos da equipe...
+                </p>
+            `;
+
+            const usuario = getUsuarioLogado();
+            const params = new URLSearchParams();
+
+            if (usuario && usuario.id) {
+                params.append('usuario_id', usuario.id);
+            }
+
+            try {
+                const resposta = await fetch(`${API_URL}/clubes/${clubeId}/carros?${params.toString()}`);
+                const projetos = await resposta.json();
+
+                if (!resposta.ok) {
+                    container.innerHTML = `
+                        <p class="garagem-equipe-vazio">
+                            Não foi possível carregar a garagem da equipe.
+                        </p>
+                    `;
+                    return;
+                }
+
+                if (!Array.isArray(projetos) || projetos.length === 0) {
+                    container.innerHTML = `
+                        <p class="garagem-equipe-vazio">
+                            Nenhum projeto cadastrado pelos membros ainda.
+                        </p>
+                    `;
+                    return;
+                }
+
+                container.innerHTML = projetos.map((projeto) => {
+                    const foto = projeto.foto_url
+                        ? `${API_URL}/uploads/${projeto.foto_url}`
+                        : '';
+
+                    return `
+                        <div class="garagem-equipe-card" data-projeto-id="${projeto.id}">
+                            ${
+                                foto
+                                    ? `<img src="${foto}" alt="" class="garagem-equipe-img">`
+                                    : `<div class="garagem-equipe-sem-foto">SEM FOTO</div>`
+                            }
+
+                            <div class="garagem-equipe-info">
+                                <strong>${projeto.modelo}</strong>
+                                <span>${projeto.ano} • Aro ${projeto.aro_roda}</span>
+                                <small>@${projeto.username_usuario || 'usuario'}</small>
+                            </div>
+                        </div>
+                    `;
+                }).join('');
+
+                container.querySelectorAll('.garagem-equipe-card').forEach((card) => {
+                    card.addEventListener('click', () => {
+                        const projeto = projetos.find((item) => {
+                            return String(item.id) === String(card.dataset.projetoId);
+                        });
+
+                        if (!projeto) {
+                            return;
+                        }
+
+                        fecharMinhaEquipe();
+                        abrirModalProjeto(projeto);
+                    });
+                });
+            } catch (erro) {
+                console.error('Erro ao carregar garagem da equipe:', erro);
+
+                container.innerHTML = `
+                    <p class="garagem-equipe-vazio">
+                        Erro ao carregar a garagem da equipe.
+                    </p>
+                `;
             }
         }
 

--- a/style.css
+++ b/style.css
@@ -921,7 +921,96 @@
             color: var(--text-muted);
             font-size: 0.9em;
             text-transform: none;
-        }     
+        }
+        
+        .garagem-equipe-bloco {
+            margin-top: 18px;
+            padding: 18px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 18px;
+            background:
+                linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent),
+                rgba(255, 255, 255, 0.03);
+        }
+
+        .equipe-garagem-texto h3 {
+            margin: 0;
+            color: var(--text-main);
+            font-size: 1rem;
+        }
+
+        .equipe-garagem-texto p {
+            margin: 4px 0 0;
+            color: var(--text-muted);
+            font-size: 0.9rem;
+        }
+
+        .garagem-equipe-lista {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+            gap: 12px;
+            margin-top: 14px;
+        }
+
+        .garagem-equipe-card {
+            overflow: hidden;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 16px;
+            background: rgba(0, 0, 0, 0.22);
+            cursor: pointer;
+            transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+        }
+
+        .garagem-equipe-card:hover {
+            transform: translateY(-2px);
+            border-color: rgba(255, 71, 87, 0.36);
+            background: rgba(255, 255, 255, 0.045);
+        }
+
+        .garagem-equipe-img,
+        .garagem-equipe-sem-foto {
+            width: 100%;
+            height: 105px;
+            object-fit: cover;
+            background: #111;
+        }
+
+        .garagem-equipe-sem-foto {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #555;
+            font-size: 0.75rem;
+            font-weight: 800;
+        }
+
+        .garagem-equipe-info {
+            padding: 11px;
+        }
+
+        .garagem-equipe-info strong {
+            display: block;
+            color: var(--text-main);
+            font-size: 0.92rem;
+        }
+
+        .garagem-equipe-info span,
+        .garagem-equipe-info small {
+            display: block;
+            margin-top: 4px;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .garagem-equipe-vazio {
+            margin: 0;
+            padding: 14px;
+            border: 1px dashed rgba(255, 255, 255, 0.12);
+            border-radius: 14px;
+            color: var(--text-muted);
+            text-align: center;
+            grid-column: 1 / -1;
+        }
 
         .feedback-container {
             position: fixed;


### PR DESCRIPTION
closes #111 

## Resumo

Exibe na garagem da equipe os projetos cadastrados pelos membros.

## Alterações

- Cria endpoint `GET /clubes/<id>/carros`
- Busca projetos de usuários presentes em `membros_clube`
- Exibe os projetos na área de garagem da equipe
- Adiciona estado vazio para equipes sem projetos
- Permite abrir o modal do projeto a partir da garagem da equipe
- Adiciona estilos para os cards da garagem da equipe

## Banco de dados

Não houve alteração estrutural no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Rodei `python -m py_compile app.py`
- [ ] Rodei `node --check script.js`
- [ ] Abri detalhes de uma equipe com projetos
- [ ] Abri detalhes de uma equipe sem projetos
- [ ] Cliquei em um projeto da garagem da equipe
- [ ] Conferi o visual no desktop
- [ ] Conferi o visual no mobile