### PR TITLE
style: melhorar cards da garagem da equipe

### DIFF
--- a/script.js
+++ b/script.js
@@ -1518,9 +1518,11 @@
             }
 
             container.innerHTML = `
-                <p class="garagem-equipe-vazio">
-                    Carregando projetos da equipe...
-                </p>
+                <div class="garagem-equipe-vazio garagem-equipe-loading">
+                    <span>🏁</span>
+                    <strong>Carregando garagem da equipe...</strong>
+                    <p>Buscando os projetos cadastrados pelos membros.</p>
+                </div>
             `;
 
             const usuario = getUsuarioLogado();
@@ -1536,18 +1538,22 @@
 
                 if (!resposta.ok) {
                     container.innerHTML = `
-                        <p class="garagem-equipe-vazio">
-                            Não foi possível carregar a garagem da equipe.
-                        </p>
+                        <div class="garagem-equipe-vazio">
+                            <span>⚠️</span>
+                            <strong>Não foi possível carregar a garagem</strong>
+                            <p>Tente abrir a equipe novamente em alguns instantes.</p>
+                        </div>
                     `;
                     return;
                 }
 
                 if (!Array.isArray(projetos) || projetos.length === 0) {
                     container.innerHTML = `
-                        <p class="garagem-equipe-vazio">
-                            Nenhum projeto cadastrado pelos membros ainda.
-                        </p>
+                        <div class="garagem-equipe-vazio">
+                            <span>🏎️</span>
+                            <strong>Nenhum projeto na garagem ainda</strong>
+                            <p>Quando os membros cadastrarem projetos, eles vão aparecer juntos aqui.</p>
+                        </div>
                     `;
                     return;
                 }
@@ -1557,18 +1563,42 @@
                         ? `${API_URL}/uploads/${projeto.foto_url}`
                         : '';
 
+                    const detalhesProjeto = [
+                        projeto.aro_roda ? `Aro ${projeto.aro_roda}` : null,
+                        projeto.cor
+                    ].filter(Boolean).join(' • ');
+
+                    const username = projeto.username_usuario || 'usuario';
+
                     return `
                         <div class="garagem-equipe-card" data-projeto-id="${projeto.id}">
-                            ${
-                                foto
-                                    ? `<img src="${foto}" alt="" class="garagem-equipe-img">`
-                                    : `<div class="garagem-equipe-sem-foto">SEM FOTO</div>`
-                            }
+                            <div class="garagem-equipe-media">
+                                ${
+                                    foto
+                                        ? `<img src="${foto}" alt="" class="garagem-equipe-img">`
+                                        : `<div class="garagem-equipe-sem-foto">SEM FOTO</div>`
+                                }
+
+                                <div class="garagem-equipe-overlay"></div>
+
+                                <span class="garagem-equipe-badge">
+                                    Equipe
+                                </span>
+                            </div>
 
                             <div class="garagem-equipe-info">
-                                <strong>${projeto.modelo}</strong>
-                                <span>${projeto.ano} • Aro ${projeto.aro_roda}</span>
-                                <small>@${projeto.username_usuario || 'usuario'}</small>
+                                <div class="garagem-equipe-titulo">
+                                    <strong>${projeto.modelo || 'Projeto sem nome'}</strong>
+                                    <span>${projeto.ano || 'Projeto'}</span>
+                                </div>
+
+                                <p class="garagem-equipe-spec">
+                                    ${detalhesProjeto || 'Detalhes do projeto'}
+                                </p>
+
+                                <div class="garagem-equipe-rodape">
+                                    <span class="garagem-equipe-dono">@${username}</span>
+                                </div>
                             </div>
                         </div>
                     `;

--- a/style.css
+++ b/style.css
@@ -1012,6 +1012,296 @@
             grid-column: 1 / -1;
         }
 
+        /* Garagem da equipe - camada premium */
+        .garagem-equipe-bloco {
+            position: relative;
+            overflow: hidden;
+            margin-top: 22px;
+            padding: 22px 28px 30px;
+            border-radius: 24px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background:
+                radial-gradient(circle at top left, rgba(255, 71, 87, 0.18), transparent 34%),
+                radial-gradient(circle at bottom right, rgba(255, 255, 255, 0.07), transparent 32%),
+                linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.018)),
+                rgba(8, 8, 8, 0.94);
+            box-shadow:
+                0 24px 70px rgba(0, 0, 0, 0.5),
+                inset 0 1px 0 rgba(255, 255, 255, 0.05);
+        }
+
+        .garagem-equipe-bloco::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            background:
+                linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.045), transparent);
+            opacity: 0.65;
+        }
+
+        .equipe-garagem-futura-topo {
+            position: relative;
+            z-index: 1;
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            margin-bottom: 6px;
+        }
+
+        .equipe-garagem-icone {
+            width: 40px;
+            height: 40px;
+            flex: 0 0 40px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 13px;
+            background:
+                radial-gradient(circle at top left, rgba(255, 71, 87, 0.34), transparent 58%),
+                rgba(255, 255, 255, 0.06);
+            border: 1px solid rgba(255, 71, 87, 0.24);
+            box-shadow: 0 12px 26px rgba(255, 71, 87, 0.13);
+        }
+
+        .equipe-garagem-texto h3 {
+            margin: 0;
+            color: var(--text-main);
+            font-size: 1.15rem;
+            letter-spacing: -0.02em;
+        }
+
+        .equipe-garagem-texto p {
+            margin: 5px 0 0;
+            color: var(--text-muted);
+            font-size: 0.9rem;
+            line-height: 1.45;
+            text-transform: none;
+        }
+
+        .garagem-equipe-lista {
+            position: relative;
+            z-index: 1;
+            display: grid;
+            grid-template-columns: repeat(auto-fill, 180px);
+            justify-content: start;
+            gap: 20px;
+            margin-top: 8px;
+            padding: 6px 14px 10px;
+        }
+
+        .garagem-equipe-card {
+            position: relative;
+            overflow: hidden;
+            min-width: 0;
+            border-radius: 22px;
+            border: 1px solid rgba(255, 255, 255, 0.095);
+            background:
+                linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.012)),
+                #0b0b0b;
+            cursor: pointer;
+            box-shadow:
+                0 18px 42px rgba(0, 0, 0, 0.42),
+                inset 0 1px 0 rgba(255, 255, 255, 0.04);
+            transition:
+                transform 0.22s ease,
+                border-color 0.22s ease,
+                box-shadow 0.22s ease,
+                background 0.22s ease;
+        }
+
+        .garagem-equipe-card:hover {
+            transform: translateY(-3px);
+            border-color: rgba(255, 71, 87, 0.42);
+            background:
+                linear-gradient(180deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.016)),
+                #101010;
+            box-shadow:
+                0 26px 58px rgba(0, 0, 0, 0.55),
+                0 0 0 1px rgba(255, 71, 87, 0.075);
+        }
+
+        .garagem-equipe-media {
+            position: relative;
+            height: 104px;
+            overflow: hidden;
+            background: #050505;
+        }
+
+        .garagem-equipe-img,
+        .garagem-equipe-sem-foto {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            background: #080808;
+            transition: transform 0.28s ease, filter 0.28s ease;
+        }
+
+        .garagem-equipe-img {
+            display: block;
+            filter: brightness(0.92) contrast(1.08) saturate(1.08);
+        }
+
+        .garagem-equipe-card:hover .garagem-equipe-img {
+            transform: scale(1.045);
+            filter: brightness(1.05) contrast(1.12) saturate(1.16);
+        }
+
+        .garagem-equipe-sem-foto {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #555;
+            font-size: 0.75rem;
+            font-weight: 900;
+            letter-spacing: 0.08em;
+            background:
+                radial-gradient(circle at center, rgba(255, 71, 87, 0.13), transparent 42%),
+                #070707;
+        }
+
+        .garagem-equipe-overlay {
+            position: absolute;
+            inset: 0;
+            background:
+                linear-gradient(to bottom, rgba(0, 0, 0, 0.08), transparent 34%, rgba(0, 0, 0, 0.62));
+            pointer-events: none;
+        }
+
+        .garagem-equipe-badge {
+            position: absolute;
+            top: 8px;
+            left: 8px;
+            max-width: calc(100% - 16px);
+            padding: 5px 8px;
+            border-radius: var(--radius-pill);
+            background: rgba(10, 10, 10, 0.54);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            color: rgba(255, 255, 255, 0.84);
+            font-size: 0.54rem;
+            font-weight: 950;
+            letter-spacing: 0.075em;
+            text-transform: uppercase;
+            backdrop-filter: blur(10px);
+        }
+
+        .garagem-equipe-info {
+            padding: 12px;
+        }
+
+        .garagem-equipe-titulo {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .garagem-equipe-titulo strong {
+            min-width: 0;
+            color: var(--text-main);
+            font-size: 0.82rem;
+            line-height: 1.15;
+            font-weight: 950;
+            letter-spacing: -0.01em;
+            text-transform: uppercase;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .garagem-equipe-titulo span {
+            flex: 0 0 auto;
+            padding: 4px 7px;
+            border-radius: var(--radius-pill);
+            background: rgba(255, 71, 87, 0.14);
+            border: 1px solid rgba(255, 71, 87, 0.28);
+            color: #ff8a94;
+            font-size: 0.62rem;
+            font-weight: 950;
+            line-height: 1;
+        }
+
+        .garagem-equipe-spec {
+            min-height: 16px;
+            margin: 7px 0 10px;
+            color: var(--text-muted);
+            font-size: 0.66rem;
+            font-weight: 850;
+            letter-spacing: 0.055em;
+            line-height: 1.35;
+            text-transform: uppercase;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .garagem-equipe-rodape {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+        }
+
+        .garagem-equipe-dono {
+            display: block;
+            min-width: 0;
+            padding-top: 9px;
+            border-top: 1px solid rgba(255, 255, 255, 0.065);
+            color: rgba(255, 255, 255, 0.74);
+            font-size: 0.7rem;
+            font-weight: 850;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            text-transform: none;
+        }
+
+        .garagem-equipe-dono::before {
+            content: "POR ";
+            color: var(--text-soft);
+            font-size: 0.58rem;
+            font-weight: 950;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .garagem-equipe-vazio {
+            grid-column: 1 / -1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            min-height: 150px;
+            margin: 0;
+            padding: 22px;
+            border: 1px dashed rgba(255, 255, 255, 0.14);
+            border-radius: 20px;
+            background:
+                radial-gradient(circle at top, rgba(255, 71, 87, 0.1), transparent 42%),
+                rgba(255, 255, 255, 0.025);
+            color: var(--text-muted);
+            text-align: center;
+            text-transform: none;
+        }
+
+        .garagem-equipe-vazio span {
+            font-size: 1.8rem;
+        }
+
+        .garagem-equipe-vazio strong {
+            color: var(--text-main);
+            font-size: 0.98rem;
+        }
+
+        .garagem-equipe-vazio p {
+            max-width: 320px;
+            margin: 0;
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            line-height: 1.45;
+        }
+
         .feedback-container {
             position: fixed;
             top: 18px;
@@ -2059,15 +2349,15 @@
             }
 
             .equipe-garagem-icone {
-                width: 52px;
-                height: 52px;
-                border-radius: 18px;
+                width: 40px;
+                height: 40px;
+                border-radius: 13px;
                 background: rgba(255, 71, 87, 0.12);
                 border: 1px solid rgba(255, 71, 87, 0.32);
                 display: flex;
                 align-items: center;
                 justify-content: center;
-                font-size: 1.45em;
+                font-size: 1.15em;
                 flex-shrink: 0;
             }
 
@@ -2916,5 +3206,40 @@
                 .pedido-equipe-acoes button {
                     width: 100%;
                     min-width: 0;
+                }
+
+                .garagem-equipe-bloco {
+                    padding: 18px;
+                    border-radius: 20px;
+                }
+
+                .equipe-garagem-futura-topo {
+                    align-items: flex-start;
+                }
+
+                .equipe-garagem-icone {
+                    width: 42px;
+                    height: 42px;
+                    flex-basis: 42px;
+                    border-radius: 14px;
+                }
+
+                .garagem-equipe-lista {
+                    grid-template-columns: 1fr;
+                    gap: 14px;
+                    padding: 4px 0 0;
+                }
+
+                .garagem-equipe-card {
+                    border-radius: 18px;
+                }
+
+                .garagem-equipe-media {
+                    height: 150px;
+                }
+
+                .garagem-equipe-rodape {
+                    align-items: flex-start;
+                    flex-direction: column;
                 }
             }


### PR DESCRIPTION
closes #113 

## Resumo

Melhora o visual dos cards da garagem da equipe, deixando a seção mais limpa, compacta e com aparência mais próxima de um app premium.

## Alterações

- Refina o bloco visual da garagem da equipe
- Reduz e reorganiza os cards dos projetos
- Remove curtidas e comentários dos cards para deixar a prévia mais limpa
- Mantém nome do projeto, ano, specs e usuário responsável
- Ajusta espaçamentos internos da garagem
- Melhora o badge dos cards
- Ajusta o visual do ícone da garagem
- Melhora a responsividade mobile dos cards

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [x] Rodei `node --check script.js`
- [x] Abri uma equipe com projetos na garagem
- [x] Conferi o visual dos cards no desktop
- [x] Conferi o visual dos cards no mobile
- [x] Cliquei em um projeto da garagem da equipe
- [x] Conferi que o modal do projeto abriu corretamente
- [x] Conferi equipe sem projetos cadastrados