### PR TITLE
refactor: limpar estilos duplicados do CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -922,95 +922,6 @@
             font-size: 0.9em;
             text-transform: none;
         }
-        
-        .garagem-equipe-bloco {
-            margin-top: 18px;
-            padding: 18px;
-            border: 1px solid rgba(255, 255, 255, 0.08);
-            border-radius: 18px;
-            background:
-                linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent),
-                rgba(255, 255, 255, 0.03);
-        }
-
-        .equipe-garagem-texto h3 {
-            margin: 0;
-            color: var(--text-main);
-            font-size: 1rem;
-        }
-
-        .equipe-garagem-texto p {
-            margin: 4px 0 0;
-            color: var(--text-muted);
-            font-size: 0.9rem;
-        }
-
-        .garagem-equipe-lista {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-            gap: 12px;
-            margin-top: 14px;
-        }
-
-        .garagem-equipe-card {
-            overflow: hidden;
-            border: 1px solid rgba(255, 255, 255, 0.08);
-            border-radius: 16px;
-            background: rgba(0, 0, 0, 0.22);
-            cursor: pointer;
-            transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
-        }
-
-        .garagem-equipe-card:hover {
-            transform: translateY(-2px);
-            border-color: rgba(255, 71, 87, 0.36);
-            background: rgba(255, 255, 255, 0.045);
-        }
-
-        .garagem-equipe-img,
-        .garagem-equipe-sem-foto {
-            width: 100%;
-            height: 105px;
-            object-fit: cover;
-            background: #111;
-        }
-
-        .garagem-equipe-sem-foto {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: #555;
-            font-size: 0.75rem;
-            font-weight: 800;
-        }
-
-        .garagem-equipe-info {
-            padding: 11px;
-        }
-
-        .garagem-equipe-info strong {
-            display: block;
-            color: var(--text-main);
-            font-size: 0.92rem;
-        }
-
-        .garagem-equipe-info span,
-        .garagem-equipe-info small {
-            display: block;
-            margin-top: 4px;
-            color: var(--text-muted);
-            font-size: 0.75rem;
-        }
-
-        .garagem-equipe-vazio {
-            margin: 0;
-            padding: 14px;
-            border: 1px dashed rgba(255, 255, 255, 0.12);
-            border-radius: 14px;
-            color: var(--text-muted);
-            text-align: center;
-            grid-column: 1 / -1;
-        }
 
         /* Garagem da equipe - camada premium */
         .garagem-equipe-bloco {
@@ -1756,18 +1667,6 @@
 
             .equipe-detalhe-header h3 {
                 font-size: 1.15em;
-            }
-
-            .btn-pedir-equipe.pedido-enviado {
-                background: rgba(255, 255, 255, 0.06);
-                border-color: rgba(255, 255, 255, 0.14);
-                color: var(--text-muted);
-                box-shadow: none;
-            }
-
-            .btn-pedir-equipe.pedido-enviado:hover {
-                transform: none;
-                box-shadow: none;
             }
 
             .equipe-membro {


### PR DESCRIPTION
closes #115 

## Resumo

Limpa estilos duplicados ou sem uso evidente no `style.css`, preservando o visual atual do projeto.

## Alterações

- Remove estilos antigos da garagem da equipe que foram substituídos pela camada visual mais recente
- Remove estilos sem uso relacionados a métricas antigas dos cards da garagem
- Remove duplicação mobile do estado `pedido-enviado`
- Mantém os ajustes mobile dentro de `@media`
- Preserva o visual atual da aplicação

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [x] Conferi o feed principal
- [x] Conferi a área Minha equipe
- [x] Conferi o detalhe da equipe
- [x] Conferi a garagem da equipe
- [x] Conferi pedidos pendentes
- [x] Conferi o visual mobile