### PR TITLE
fix: voltar para equipe ao fechar projeto

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@
         const API_URL = 'http://127.0.0.1:5000';
         let todosCarros = [];
         let modoGaragem = "todos";
+        let equipeParaReabrirAposProjeto = null;
 
         if ('scrollRestoration' in history) {
             history.scrollRestoration = 'manual';
@@ -723,11 +724,17 @@
         function fecharModalProjeto() {
             const modal = document.getElementById('modal-projeto');
             const modalContent = document.getElementById('modal-content');
+            const equipeIdParaReabrir = equipeParaReabrirAposProjeto;
+
+            equipeParaReabrirAposProjeto = null;
 
             resetarScrollModalProjeto();
 
             modal.style.display = "none";
-            document.body.style.overflow = "";
+
+            if (!equipeIdParaReabrir) {
+                document.body.style.overflow = "";
+            }
 
             if (modalContent) {
                 modalContent.classList.remove("trocando-conteudo");
@@ -735,6 +742,10 @@
             }
 
             setTimeout(resetarScrollModalProjeto, 0);
+
+            if (equipeIdParaReabrir) {
+                abrirEquipe(equipeIdParaReabrir);
+            }
         }
 
         const modalProjeto = document.getElementById('modal-projeto');
@@ -1614,6 +1625,7 @@
                             return;
                         }
 
+                        equipeParaReabrirAposProjeto = clubeId;
                         fecharMinhaEquipe();
                         abrirModalProjeto(projeto);
                     });


### PR DESCRIPTION
closes #117 

## Resumo

Corrige o fluxo ao abrir um projeto a partir da garagem da equipe.

## Alterações

- Salva a equipe de origem ao abrir um projeto pela garagem da equipe
- Fecha temporariamente a equipe antes de abrir o modal do projeto
- Reabre a equipe ao fechar o modal do projeto
- Mantém o comportamento normal para projetos abertos pelo feed

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [x] Rodei `node --check script.js`
- [x] Abri um projeto pela garagem da equipe
- [x] Fechei o projeto e confirmei que a equipe reabre
- [x] Abri um projeto pelo feed normal
- [x] Fechei o projeto e confirmei que nenhuma equipe abre