### PR TITLE
feat: adicionar garagem completa da equipe

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@
         let todosCarros = [];
         let modoGaragem = "todos";
         let equipeParaReabrirAposProjeto = null;
+        let garagemCompletaParaReabrirAposProjeto = null;
 
         if ('scrollRestoration' in history) {
             history.scrollRestoration = 'manual';
@@ -721,19 +722,34 @@
             setTimeout(() => carregarComentarios(carro.id), 100);
         }
 
+        function restaurarScrollBodySeNaoHouverModalAberto() {
+            const modalProjeto = document.getElementById('modal-projeto');
+            const modalEquipe = document.getElementById('modal-minha-equipe');
+            const garagemCompletaAberta = document.querySelector('.garagem-completa-overlay');
+
+            const projetoAberto = modalProjeto && modalProjeto.style.display === 'block';
+            const equipeAberta = modalEquipe && modalEquipe.style.display === 'block';
+
+            if (!projetoAberto && !equipeAberta && !garagemCompletaAberta) {
+                document.body.style.overflow = "";
+            }
+        }
+
         function fecharModalProjeto() {
             const modal = document.getElementById('modal-projeto');
             const modalContent = document.getElementById('modal-content');
             const equipeIdParaReabrir = equipeParaReabrirAposProjeto;
+            const garagemCompletaParaReabrir = garagemCompletaParaReabrirAposProjeto;
 
             equipeParaReabrirAposProjeto = null;
+            garagemCompletaParaReabrirAposProjeto = null;
 
             resetarScrollModalProjeto();
 
             modal.style.display = "none";
 
-            if (!equipeIdParaReabrir) {
-                document.body.style.overflow = "";
+            if (!equipeIdParaReabrir && !garagemCompletaParaReabrir) {
+                restaurarScrollBodySeNaoHouverModalAberto();
             }
 
             if (modalContent) {
@@ -742,6 +758,15 @@
             }
 
             setTimeout(resetarScrollModalProjeto, 0);
+
+            if (garagemCompletaParaReabrir) {
+                abrirEquipe(garagemCompletaParaReabrir.clubeId);
+                abrirGaragemCompletaEquipe(
+                    garagemCompletaParaReabrir.clubeId,
+                    garagemCompletaParaReabrir.nomeEquipe
+                );
+                return;
+            }
 
             if (equipeIdParaReabrir) {
                 abrirEquipe(equipeIdParaReabrir);
@@ -1399,6 +1424,7 @@
             if (modal) {
                 modal.style.display = 'none';
             }
+            restaurarScrollBodySeNaoHouverModalAberto();
         }
 
         function textoSeguro(valor) {
@@ -1504,6 +1530,8 @@
                                 Carregando projetos da equipe...
                             </p>
                         </div>
+
+                        <div id="garagem-equipe-acoes" class="garagem-equipe-acoes"></div>
                     </div>
                 `;
 
@@ -1513,7 +1541,7 @@
                 carregarPedidosEquipe(equipe.id);
             }
 
-            carregarGaragemEquipe(equipe.id);
+            carregarGaragemEquipe(equipe.id, equipe.nome);
 
             } catch (erro) {
                 console.error('Erro ao abrir equipe:', erro);
@@ -1521,11 +1549,62 @@
             }
         }
 
-        async function carregarGaragemEquipe(clubeId) {
+        function montarCardGaragemEquipe(projeto) {
+            const foto = projeto.foto_url
+                ? `${API_URL}/uploads/${projeto.foto_url}`
+                : '';
+
+            const detalhesProjeto = [
+                projeto.aro_roda ? `Aro ${projeto.aro_roda}` : null,
+                projeto.cor
+            ].filter(Boolean).join(' • ');
+
+            const username = projeto.username_usuario || 'usuario';
+
+            return `
+                <div class="garagem-equipe-card" data-projeto-id="${projeto.id}">
+                    <div class="garagem-equipe-media">
+                        ${
+                            foto
+                                ? `<img src="${foto}" alt="" class="garagem-equipe-img">`
+                                : `<div class="garagem-equipe-sem-foto">SEM FOTO</div>`
+                        }
+
+                        <div class="garagem-equipe-overlay"></div>
+
+                        <span class="garagem-equipe-badge">
+                            Equipe
+                        </span>
+                    </div>
+
+                    <div class="garagem-equipe-info">
+                        <div class="garagem-equipe-titulo">
+                            <strong>${projeto.modelo || 'Projeto sem nome'}</strong>
+                            <span>${projeto.ano || 'Projeto'}</span>
+                        </div>
+
+                        <p class="garagem-equipe-spec">
+                            ${detalhesProjeto || 'Detalhes do projeto'}
+                        </p>
+
+                        <div class="garagem-equipe-rodape">
+                            <span class="garagem-equipe-dono">@${username}</span>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }
+
+        async function carregarGaragemEquipe(clubeId, nomeEquipe = 'Equipe') {
             const container = document.getElementById('garagem-equipe-lista');
+            const acoesContainer = document.getElementById('garagem-equipe-acoes');
 
             if (!container) {
                 return;
+            }
+
+            if (acoesContainer) {
+                acoesContainer.innerHTML = '';
             }
 
             container.innerHTML = `
@@ -1569,51 +1648,23 @@
                     return;
                 }
 
-                container.innerHTML = projetos.map((projeto) => {
-                    const foto = projeto.foto_url
-                        ? `${API_URL}/uploads/${projeto.foto_url}`
-                        : '';
+                const projetosPreview = projetos.slice(0, 3);
 
-                    const detalhesProjeto = [
-                        projeto.aro_roda ? `Aro ${projeto.aro_roda}` : null,
-                        projeto.cor
-                    ].filter(Boolean).join(' • ');
-
-                    const username = projeto.username_usuario || 'usuario';
-
-                    return `
-                        <div class="garagem-equipe-card" data-projeto-id="${projeto.id}">
-                            <div class="garagem-equipe-media">
-                                ${
-                                    foto
-                                        ? `<img src="${foto}" alt="" class="garagem-equipe-img">`
-                                        : `<div class="garagem-equipe-sem-foto">SEM FOTO</div>`
-                                }
-
-                                <div class="garagem-equipe-overlay"></div>
-
-                                <span class="garagem-equipe-badge">
-                                    Equipe
-                                </span>
-                            </div>
-
-                            <div class="garagem-equipe-info">
-                                <div class="garagem-equipe-titulo">
-                                    <strong>${projeto.modelo || 'Projeto sem nome'}</strong>
-                                    <span>${projeto.ano || 'Projeto'}</span>
-                                </div>
-
-                                <p class="garagem-equipe-spec">
-                                    ${detalhesProjeto || 'Detalhes do projeto'}
-                                </p>
-
-                                <div class="garagem-equipe-rodape">
-                                    <span class="garagem-equipe-dono">@${username}</span>
-                                </div>
-                            </div>
-                        </div>
-                    `;
+                container.innerHTML = projetosPreview.map((projeto) => {
+                    return montarCardGaragemEquipe(projeto);
                 }).join('');
+
+                if (acoesContainer && projetos.length > projetosPreview.length) {
+                    acoesContainer.innerHTML = `
+                        <button
+                            type="button"
+                            class="btn-garagem-completa"
+                            onclick="abrirGaragemCompletaEquipe(${clubeId}, '${String(nomeEquipe || 'Equipe').replace(/'/g, "\\'")}')"
+                        >
+                            Ver garagem completa
+                        </button>
+                    `;
+                }
 
                 container.querySelectorAll('.garagem-equipe-card').forEach((card) => {
                     card.addEventListener('click', () => {
@@ -1637,6 +1688,119 @@
                     <p class="garagem-equipe-vazio">
                         Erro ao carregar a garagem da equipe.
                     </p>
+                `;
+            }
+        }
+
+        async function abrirGaragemCompletaEquipe(clubeId, nomeEquipe = 'Equipe') {
+            const overlayExistente = document.querySelector('.garagem-completa-overlay');
+
+            if (overlayExistente) {
+                overlayExistente.remove();
+            }
+
+            const overlay = document.createElement('div');
+            overlay.className = 'garagem-completa-overlay';
+
+            overlay.innerHTML = `
+                <div class="garagem-completa-modal">
+                    <div class="garagem-completa-header">
+                        <div>
+                            <span>Garagem coletiva</span>
+                            <h2>${textoFeedbackSeguro(nomeEquipe)}</h2>
+                            <p>Projetos cadastrados pelos membros da equipe.</p>
+                        </div>
+
+                        <button
+                            type="button"
+                            class="garagem-completa-fechar"
+                            aria-label="Fechar garagem completa"
+                        >
+                            ×
+                        </button>
+                    </div>
+
+                    <div id="garagem-completa-lista" class="garagem-completa-lista"></div>
+                </div>
+            `;
+
+            document.body.appendChild(overlay);
+            document.body.style.overflow = 'hidden';
+
+            const fecharGaragemCompleta = () => {
+                overlay.remove();
+                restaurarScrollBodySeNaoHouverModalAberto();
+            };
+
+            overlay.querySelector('.garagem-completa-fechar').addEventListener('click', fecharGaragemCompleta);
+
+            overlay.addEventListener('click', (event) => {
+                if (event.target === overlay) {
+                    fecharGaragemCompleta();
+                }
+            });
+
+            const lista = overlay.querySelector('#garagem-completa-lista');
+
+            try {
+                const resposta = await fetch(`${API_URL}/clubes/${clubeId}/carros`);
+                const projetos = await resposta.json();
+
+                if (!resposta.ok) {
+                    lista.innerHTML = `
+                        <div class="garagem-equipe-vazio">
+                            <span>⚠️</span>
+                            <strong>Não foi possível carregar a garagem</strong>
+                            <p>Tente abrir a equipe novamente em alguns instantes.</p>
+                        </div>
+                    `;
+                    return;
+                }
+
+                if (!Array.isArray(projetos) || projetos.length === 0) {
+                    lista.innerHTML = `
+                        <div class="garagem-equipe-vazio">
+                            <span>🏎️</span>
+                            <strong>Nenhum projeto na garagem ainda</strong>
+                            <p>Quando os membros cadastrarem projetos, eles vão aparecer juntos aqui.</p>
+                        </div>
+                    `;
+                    return;
+                }
+
+                lista.innerHTML = projetos.map((projeto) => {
+                    return montarCardGaragemEquipe(projeto);
+                }).join('');
+
+                lista.querySelectorAll('.garagem-equipe-card').forEach((card) => {
+                    card.addEventListener('click', () => {
+                        const projeto = projetos.find((item) => {
+                            return String(item.id) === String(card.dataset.projetoId);
+                        });
+
+                        if (!projeto) {
+                            return;
+                        }
+
+                        garagemCompletaParaReabrirAposProjeto = {
+                            clubeId,
+                            nomeEquipe
+                        };
+
+                        overlay.remove();
+                        fecharMinhaEquipe();
+                        abrirModalProjeto(projeto);
+                    });
+                });
+            } catch (erro) {
+                console.error('Erro ao carregar garagem completa da equipe:', erro);
+
+                lista.innerHTML = `
+                    <div class="garagem-equipe-vazio">
+                        <span>⚠️</span>
+                        <strong>Erro ao carregar garagem completa</strong>
+                        <p>Verifique a conexão e tente novamente.</p>
+                    </div>
                 `;
             }
         }

--- a/style.css
+++ b/style.css
@@ -1044,7 +1044,7 @@
         .garagem-equipe-img,
         .garagem-equipe-sem-foto {
             width: 100%;
-            height: 124%;
+            height: 124px;
             object-fit: cover;
             background: #080808;
             transition: transform 0.28s ease, filter 0.28s ease;

--- a/style.css
+++ b/style.css
@@ -928,7 +928,7 @@
             position: relative;
             overflow: hidden;
             margin-top: 22px;
-            padding: 22px 28px 30px;
+            padding: 26px 32px 38px;
             border-radius: 24px;
             border: 1px solid rgba(255, 255, 255, 0.1);
             background:
@@ -990,15 +990,17 @@
             text-transform: none;
         }
 
-        .garagem-equipe-lista {
-            position: relative;
-            z-index: 1;
+        .garagem-equipe-bloco .garagem-equipe-lista {
             display: grid;
-            grid-template-columns: repeat(auto-fill, 180px);
-            justify-content: start;
-            gap: 20px;
-            margin-top: 8px;
-            padding: 6px 14px 10px;
+            grid-template-columns: repeat(3, 210px);
+            justify-content: center;
+            gap: 26px;
+            margin-top: 18px;
+            padding: 0 18px;
+        }
+
+        .garagem-equipe-bloco .garagem-equipe-card {
+            width: 210px;
         }
 
         .garagem-equipe-card {
@@ -1042,7 +1044,7 @@
         .garagem-equipe-img,
         .garagem-equipe-sem-foto {
             width: 100%;
-            height: 100%;
+            height: 124%;
             object-fit: cover;
             background: #080808;
             transition: transform 0.28s ease, filter 0.28s ease;
@@ -1177,6 +1179,7 @@
         }
 
         .garagem-equipe-vazio {
+            width: 100%;
             grid-column: 1 / -1;
             display: flex;
             flex-direction: column;
@@ -1211,6 +1214,154 @@
             color: var(--text-muted);
             font-size: 0.85rem;
             line-height: 1.45;
+        }
+
+        /* Garagem completa da equipe */
+        .garagem-equipe-acoes {
+            position: relative;
+            z-index: 2;
+            display: flex;
+            justify-content: center;
+            margin-top: 22px;
+            margin-bottom: 12px;
+            padding: 0;
+        }
+
+        .btn-garagem-completa {
+            width: auto;
+            min-width: max-content;
+            margin: 0;
+            padding: 9px 14px;
+            border: 1px solid rgba(255, 71, 87, 0.32);
+            border-radius: var(--radius-pill);
+            background: rgba(255, 71, 87, 0.1);
+            color: #ff8a94;
+            font-size: 0.68rem;
+            font-weight: 950;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            cursor: pointer;
+            white-space: nowrap;
+            box-shadow: 0 14px 34px rgba(255, 71, 87, 0.08);
+            transition:
+                transform 0.2s ease,
+                background 0.2s ease,
+                border-color 0.2s ease,
+                box-shadow 0.2s ease;
+        }
+
+        .btn-garagem-completa:hover {
+            transform: translateY(-1px);
+            background: rgba(255, 71, 87, 0.16);
+            border-color: rgba(255, 71, 87, 0.48);
+            box-shadow: 0 18px 40px rgba(255, 71, 87, 0.12);
+        }
+
+        .garagem-completa-overlay {
+            position: fixed;
+            inset: 0;
+            z-index: 10000;
+            display: flex;
+            align-items: flex-start;
+            justify-content: center;
+            padding: 38px 18px;
+            background: rgba(0, 0, 0, 0.78);
+            backdrop-filter: blur(14px);
+            overflow-y: auto;
+        }
+
+        .garagem-completa-modal {
+            width: min(1120px, 100%);
+            min-height: 430px;
+            overflow: hidden;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 28px;
+            background:
+                radial-gradient(circle at top left, rgba(255, 71, 87, 0.16), transparent 32%),
+                linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.018)),
+                #090909;
+            box-shadow: 0 34px 90px rgba(0, 0, 0, 0.68);
+        }
+
+        .garagem-completa-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 18px;
+            padding: 28px 32px 20px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+        }
+
+        .garagem-completa-header > div {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+        }
+
+        .garagem-completa-header > div span,
+        .garagem-completa-header > div h2,
+        .garagem-completa-header > div p {
+            margin-left: 0;
+            padding-left: 0;
+            text-indent: 0;
+            align-self: flex-start;
+        }
+
+        .garagem-completa-header span {
+            display: block;
+            margin-bottom: 8px;
+            color: #ff7c88;
+            font-size: 0.68rem;
+            font-weight: 950;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        .garagem-completa-header h2 {
+            margin: 0;
+            color: var(--text-main);
+            font-size: 1.55rem;
+            line-height: 1.08;
+            letter-spacing: -0.03em;
+            text-transform: uppercase;
+        }
+
+        .garagem-completa-header p {
+            margin: 8px 0 0;
+            color: var(--text-muted);
+            font-size: 0.92rem;
+            line-height: 1.4;
+            text-transform: none;
+        }
+
+        .garagem-completa-fechar {
+            width: 42px;
+            height: 42px;
+            flex: 0 0 42px;
+            margin: 0;
+            padding: 0;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 14px;
+            background: rgba(255, 255, 255, 0.055);
+            color: var(--text-main);
+            font-size: 1.5rem;
+            cursor: pointer;
+        }
+
+        .garagem-completa-fechar:hover {
+            background: rgba(255, 71, 87, 0.16);
+            border-color: rgba(255, 71, 87, 0.42);
+        }
+
+        .garagem-completa-lista {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, 220px);
+            gap: 22px;
+            justify-content: start;
+            padding: 26px 32px 34px;
+        }
+
+        .garagem-completa-lista .garagem-equipe-card {
+            width: 220px;
         }
 
         .feedback-container {
@@ -3140,5 +3291,48 @@
                 .garagem-equipe-rodape {
                     align-items: flex-start;
                     flex-direction: column;
+                }
+
+                .garagem-equipe-acoes {
+                    justify-content: stretch;
+                    margin-top: 14px;
+                }
+
+                .btn-garagem-completa {
+                    width: 100%;
+                    text-align: center;
+                }
+
+                .garagem-completa-overlay {
+                    padding: 12px;
+                }
+
+                .garagem-completa-modal {
+                    min-height: calc(100vh - 24px);
+                    border-radius: 22px;
+                }
+
+                .garagem-completa-header {
+                    padding: 22px 18px 16px;
+                }
+
+                .garagem-completa-header h2 {
+                    font-size: 1.22rem;
+                }
+
+                .garagem-completa-lista {
+                    grid-template-columns: 1fr;
+                    gap: 14px;
+                    padding: 18px;
+                }
+
+                .garagem-equipe-bloco .garagem-equipe-lista {
+                    grid-template-columns: 1fr;
+                    gap: 14px;
+                }
+
+                .garagem-equipe-bloco .garagem-equipe-card,
+                .garagem-completa-lista .garagem-equipe-card {
+                    width: 100%;
                 }
             }


### PR DESCRIPTION
closes #119 

## Resumo

Adiciona uma visualização completa da garagem da equipe, permitindo acessar todos os projetos cadastrados pelos membros em um modal próprio.

## Alterações

- Cria função reutilizável para montar cards da garagem da equipe
- Limita a prévia da garagem a até 3 projetos
- Exibe o botão "Ver garagem completa" apenas quando há mais projetos além da prévia
- Adiciona modal de garagem coletiva completa
- Permite abrir projetos a partir da garagem completa
- Ajusta o retorno ao fechar projeto:
  - Projeto aberto pela prévia volta para a equipe
  - Projeto aberto pela garagem completa volta para a garagem completa
- Ajusta controle de scroll ao fechar modais sobrepostos
- Adiciona estilos da garagem completa e do botão da garagem
- Ajusta alinhamento do cabeçalho da garagem completa

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [x] Rodei `node --check script.js`
- [x] Testei equipe com até 3 projetos
- [x] Testei equipe com 4+ projetos
- [x] Testei o botão "Ver garagem completa"
- [x] Testei abrir projeto pela prévia da garagem
- [x] Testei abrir projeto pela garagem completa
- [x] Testei fechar projeto e voltar para equipe
- [x] Testei fechar projeto e voltar para garagem completa
- [x] Testei fechar garagem completa e voltar para equipe
- [x] Testei o scroll da página inicial após fechar os modais
- [x] Testei visualmente no mobile