### PR TITLE
style: melhorar conteudo do modal de projeto

### DIFF
--- a/style.css
+++ b/style.css
@@ -645,12 +645,18 @@
         }
 
         .dono-link {
-            color: #ff4757;
+            color: var(--accent);
+            font-weight: 900;
             cursor: pointer;
+            transition:
+                color var(--transition-fast),
+                text-shadow var(--transition-fast);
         }
 
         .dono-link:hover {
-            text-decoration: underline;
+            color: #ff7a84;
+            text-decoration: none;
+            text-shadow: 0 0 18px rgba(255, 71, 87, 0.28);
         }
 
         .destaque {
@@ -837,73 +843,96 @@
 
         .modal-img {
             width: 100%;
-            height: 460px;
+            height: 440px;
             object-fit: cover;
             display: block;
             background-color: #000;
-            filter: brightness(0.96) contrast(1.08) saturate(1.08);
+            filter: brightness(0.94) contrast(1.1) saturate(1.1);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
         }
 
         .modal-sem-foto {
-            height: 360px;
+            height: 340px;
             display: flex;
             align-items: center;
             justify-content: center;
-            color: #444;
+            color: rgba(255, 255, 255, 0.24);
             background:
-                radial-gradient(circle at center, rgba(255, 71, 87, 0.08), transparent 38%),
+                radial-gradient(circle at center, rgba(255, 71, 87, 0.12), transparent 38%),
+                linear-gradient(145deg, rgba(255, 255, 255, 0.035), transparent),
                 #050505;
-            font-weight: 900;
+            font-size: 0.82rem;
+            font-weight: 950;
             text-transform: uppercase;
-            letter-spacing: 0.08em;
+            letter-spacing: 0.12em;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
         }
 
         .modal-info {
-            padding: 28px;
+            padding: 30px;
             text-transform: uppercase;
+            background:
+                radial-gradient(circle at top left, rgba(255, 71, 87, 0.065), transparent 30%),
+                linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 26%);
         }
 
         .modal-info h2 {
+            position: relative;
             text-align: left;
             color: #fff;
             font-size: clamp(1.7em, 4vw, 2.25em);
-            margin: 0 0 18px 0;
+            margin: 0 0 20px 0;
+            padding-left: 16px;
+            letter-spacing: -0.055em;
+            line-height: 1.02;
             border-left: 4px solid var(--accent);
-            padding-left: 14px;
-            letter-spacing: -0.5px;
-            line-height: 1.08;
+            text-shadow: 0 16px 34px rgba(0, 0, 0, 0.42);
         }
 
         .modal-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
             gap: 12px;
             margin-top: 22px;
         }
 
         .modal-item {
             background:
-                linear-gradient(145deg, rgba(255, 255, 255, 0.035), transparent),
-                var(--bg-card);
-            border: 1px solid var(--border-soft);
-            border-radius: var(--radius-md);
-            padding: 14px;
-            box-shadow: 0 8px 18px rgba(0, 0, 0, 0.18);
+                linear-gradient(145deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012)),
+                rgba(10, 10, 10, 0.62);
+            border: 1px solid rgba(255, 255, 255, 0.085);
+            border-radius: var(--radius-lg);
+            padding: 15px;
+            box-shadow: 0 10px 22px rgba(0, 0, 0, 0.18);
         }
 
         .modal-item span {
             display: block;
             color: var(--text-soft);
-            font-size: 0.72em;
-            font-weight: 850;
-            margin-bottom: 6px;
-            letter-spacing: 1px;
+            font-size: 0.68rem;
+            font-weight: 950;
+            margin-bottom: 7px;
+            letter-spacing: 0.095em;
+            text-transform: uppercase;
         }
 
         .modal-item strong {
-            color: #f1f1f1;
-            font-size: 1.02em;
-            line-height: 1.3;
+            display: block;
+            color: var(--text-main);
+            font-size: 1rem;
+            font-weight: 900;
+            line-height: 1.32;
+            text-transform: uppercase;
+        }
+
+        .modal-item .dono-link {
+            color: var(--accent);
+            font-weight: 950;
+        }
+
+        .modal-item .dono-link:hover {
+            color: #ff7a84;
+            text-shadow: 0 0 18px rgba(255, 71, 87, 0.28);
         }
 
         .comentarios-container {
@@ -2458,14 +2487,6 @@
                     linear-gradient(145deg, rgba(255, 71, 87, 0.22), rgba(255, 71, 87, 0.1));
                 border-color: rgba(255, 71, 87, 0.62);
                 color: #ff6b78;
-            }
-
-            .modal .dono-link {
-                color: #ff4757;
-            }
-
-            .modal .dono-link:hover {
-                text-decoration: underline;
             }
 
             .modal,


### PR DESCRIPTION
closes #129 

## Resumo

Melhora o visual do conteúdo principal do modal de projeto, deixando a tela de detalhes mais premium e coerente com os cards e comentários atualizados.

## Alterações

- Refina imagem principal do modal
- Melhora placeholder de projeto sem imagem
- Ajusta espaçamento e background da área de informações
- Melhora hierarquia visual do título do projeto
- Refina grid da ficha técnica
- Melhora cards de informações técnicas
- Padroniza valores da ficha técnica em maiúsculo
- Refina estilo do link do dono do projeto
- Remove estilo duplicado do link do dono no modal

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Rodei `node --check script.js`
- [ ] Testei abrir modal de projeto
- [ ] Testei projeto com imagem
- [ ] Testei projeto sem imagem
- [ ] Testei ficha técnica do projeto
- [ ] Testei link do dono do projeto
- [ ] Testei abrir perfil pelo dono
- [ ] Testei fechar modal
- [ ] Testei visualmente no mobile