### PR TITLE
style: suavizar transicoes entre modais

### DIFF
--- a/script.js
+++ b/script.js
@@ -631,6 +631,11 @@
         function abrirModalProjeto(carro, scrollManter = null) {
             const modal = document.getElementById('modal-projeto');
             const modalContent = document.getElementById('modal-content');
+            const modalJaAberto = modal.style.display === "block";
+
+            if (modalJaAberto && modalContent) {
+                modalContent.classList.add("trocando-conteudo");
+            }
 
             modal.style.display = "block";
             document.body.style.overflow = "hidden";
@@ -713,10 +718,15 @@
                 </div>
             `;
 
-            setTimeout(() => {
+            requestAnimationFrame(() => {
+                if (modalContent) {
+                    modalContent.classList.remove("trocando-conteudo");
+                    modalContent.style.visibility = "visible";
+                }
+
                 modal.scrollTop = 0;
                 modalContent.scrollTop = 0;
-            }, 0);
+            });
 
             setTimeout(() => carregarComentarios(carro.id), 100);
         }
@@ -745,6 +755,38 @@
             garagemCompletaParaReabrirAposProjeto = null;
             perfilParaReabrirAposProjeto = null;
 
+            if (perfilIdParaReabrir) {
+                if (modalContent) {
+                    modalContent.classList.add("trocando-conteudo");
+                    modalContent.style.visibility = "visible";
+                }
+
+                abrirPerfil(perfilIdParaReabrir);
+                return;
+            }
+
+            if (equipeIdParaReabrir) {
+                if (modalContent) {
+                    modalContent.classList.add("trocando-conteudo");
+                    modalContent.style.visibility = "visible";
+                }
+
+                setTimeout(() => {
+                    resetarScrollModalProjeto();
+
+                    modal.style.display = "none";
+
+                    if (modalContent) {
+                        modalContent.classList.remove("trocando-conteudo");
+                        modalContent.style.visibility = "visible";
+                    }
+
+                    abrirEquipe(equipeIdParaReabrir);
+                }, 120);
+
+                return;
+            }
+
             resetarScrollModalProjeto();
 
             modal.style.display = "none";
@@ -766,11 +808,6 @@
                     garagemCompletaParaReabrir.clubeId,
                     garagemCompletaParaReabrir.nomeEquipe
                 );
-                return;
-            }
-
-            if (equipeIdParaReabrir) {
-                abrirEquipe(equipeIdParaReabrir);
                 return;
             }
 

--- a/style.css
+++ b/style.css
@@ -2495,11 +2495,14 @@
             }
 
             .modal-content {
-                transition: opacity 0.12s ease;
+                transition:
+                    opacity 0.16s ease,
+                    transform 0.16s ease;
             }
 
             .modal-content.trocando-conteudo {
                 opacity: 0;
+                transform: translateY(6px) scale(0.99);
             }
 
             .equipe-modal-info {


### PR DESCRIPTION
closes #135 

## Resumo

Suaviza transições ao abrir projetos a partir de outras telas do app, reduzindo piscadas visuais entre modais.

## Alterações

- Refina a transição visual do `modal-content`
- Adiciona transição com opacidade e leve movimento
- Aplica transição ao abrir projeto enquanto outro conteúdo do modal está aberto
- Suaviza retorno ao perfil ao fechar projeto aberto pelo perfil
- Suaviza retorno à equipe ao fechar projeto aberto pela equipe
- Mantém o comportamento normal ao abrir projeto direto pelo feed

## Fora do escopo

- Não altera backend
- Não altera banco de dados
- Não altera regras de projeto
- Não altera regras de equipe
- Não altera comentários/curtidas
- Não refatora toda a estrutura de modais
- Não altera ainda o fluxo da garagem completa

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Rodei `node --check script.js`
- [ ] Testei abrir projeto pelo feed
- [ ] Testei fechar projeto aberto pelo feed
- [ ] Testei abrir projeto pelo perfil
- [ ] Testei fechar projeto aberto pelo perfil e voltar ao perfil
- [ ] Testei abrir projeto pela equipe
- [ ] Testei fechar projeto aberto pela equipe e voltar à equipe
- [ ] Testei no mobile