### PR TITLE
style: refinar feedbacks no mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1696,20 +1696,38 @@
         }
 
         .feedback-item {
+            --feedback-accent: var(--accent);
+            --feedback-glow: rgba(255, 71, 87, 0.12);
+
+            position: relative;
+            overflow: hidden;
             pointer-events: auto;
             display: flex;
             align-items: flex-start;
             justify-content: space-between;
             gap: 12px;
-            padding: 14px 14px 14px 16px;
+            padding: 14px 14px 14px 17px;
             border: 1px solid rgba(255, 255, 255, 0.1);
             border-radius: var(--radius-lg);
             background:
-                linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent),
-                #131313;
+                radial-gradient(circle at top left, var(--feedback-glow), transparent 36%),
+                linear-gradient(145deg, rgba(255, 255, 255, 0.05), transparent),
+                rgba(19, 19, 19, 0.96);
             box-shadow: 0 18px 42px rgba(0, 0, 0, 0.42);
+            backdrop-filter: blur(12px);
             animation: feedbackEntrando 0.25s ease forwards;
             text-transform: none;
+        }
+
+        .feedback-item::before {
+            content: "";
+            position: absolute;
+            top: 12px;
+            bottom: 12px;
+            left: 0;
+            width: 3px;
+            border-radius: var(--radius-pill);
+            background: var(--feedback-accent);
         }
 
         .feedback-item.saindo {
@@ -1725,28 +1743,34 @@
         .feedback-conteudo strong {
             display: block;
             color: #fff;
-            font-size: 0.88em;
+            font-size: 0.78rem;
             margin-bottom: 4px;
             text-transform: uppercase;
-            letter-spacing: 0.04em;
+            letter-spacing: 0.075em;
         }
 
         .feedback-conteudo span {
             display: block;
             color: var(--text-muted);
-            font-size: 0.88em;
+            font-size: 0.88rem;
             line-height: 1.4;
             text-transform: none;
         }
 
         .feedback-sucesso {
-            border-color: rgba(46, 213, 115, 0.38);
+            --feedback-accent: #35d07f;
+            --feedback-glow: rgba(53, 208, 127, 0.12);
+
+            border-color: rgba(53, 208, 127, 0.34);
             box-shadow:
                 0 18px 42px rgba(0, 0, 0, 0.42),
-                0 0 0 1px rgba(46, 213, 115, 0.08);
+                0 0 0 1px rgba(53, 208, 127, 0.08);
         }
 
         .feedback-erro {
+            --feedback-accent: var(--accent);
+            --feedback-glow: rgba(255, 71, 87, 0.12);
+
             border-color: rgba(255, 71, 87, 0.48);
             box-shadow:
                 0 18px 42px rgba(0, 0, 0, 0.42),
@@ -1754,28 +1778,38 @@
         }
 
         .feedback-aviso {
-            border-color: rgba(255, 184, 108, 0.42);
+            --feedback-accent: #ffd166;
+            --feedback-glow: rgba(255, 209, 102, 0.12);
+
+            border-color: rgba(255, 209, 102, 0.38);
             box-shadow:
                 0 18px 42px rgba(0, 0, 0, 0.42),
-                0 0 0 1px rgba(255, 184, 108, 0.08);
+                0 0 0 1px rgba(255, 209, 102, 0.08);
         }
 
         .feedback-fechar {
-            width: auto;
-            min-height: auto;
+            width: 30px;
+            min-width: 30px;
+            min-height: 30px;
+            height: 30px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
             margin: 0;
-            padding: 2px 8px;
-            border: 1px solid rgba(255, 255, 255, 0.08);
-            border-radius: var(--radius-pill);
-            background: rgba(255, 255, 255, 0.04);
+            padding: 0;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.045);
             color: var(--text-muted);
-            font-size: 1em;
-            line-height: 1.3;
+            font-size: 1rem;
+            line-height: 1;
+            text-transform: none;
         }
 
         .feedback-fechar:hover {
             color: #fff;
             border-color: rgba(255, 255, 255, 0.2);
+            background: rgba(255, 255, 255, 0.075);
             transform: none;
         }
 
@@ -2323,17 +2357,42 @@
             }
 
             .feedback-container {
-                top: 12px;
-                left: 10px;
-                right: 10px;
+                top: max(18px, env(safe-area-inset-top));
+                left: 12px;
+                right: 12px;
                 width: auto;
+                gap: 8px;
             }
 
             .feedback-item {
-                border-radius: 16px;
-                padding: 13px;
+                gap: 10px;
+                border-radius: 18px;
+                padding: 12px 12px 12px 15px;
+                box-shadow: 0 16px 38px rgba(0, 0, 0, 0.44);
             }
 
+            .feedback-item::before {
+                top: 11px;
+                bottom: 11px;
+            }
+
+            .feedback-conteudo strong {
+                font-size: 0.68rem;
+                letter-spacing: 0.08em;
+            }
+
+            .feedback-conteudo span {
+                font-size: 0.8rem;
+                line-height: 1.35;
+            }
+
+            .feedback-fechar {
+                width: 28px;
+                min-width: 28px;
+                min-height: 28px;
+                height: 28px;
+                font-size: 0.95rem;
+            }
         }
 
             #lista-equipes.equipes-lista {


### PR DESCRIPTION
closes #142

## Resumo

Refina o visual das mensagens de feedback, deixando os alertas de sucesso, erro e aviso mais legíveis, modernos e próximos de uma experiência de app, especialmente no mobile.

## Alterações

- Melhora o visual dos feedbacks globais
- Adiciona destaque lateral de cor por tipo de mensagem
- Refina fundo, borda, sombra e sensação de toast
- Melhora hierarquia do título e texto da mensagem
- Refina o botão de fechar
- Ajusta espaçamento e largura dos feedbacks no mobile
- Mantém a mudança limitada ao CSS

## Fora do escopo

- Não altera HTML
- Não altera JavaScript
- Não altera o funcionamento do `mostrarMensagem`
- Não altera textos das mensagens
- Não altera login, cadastro, curtidas, comentários ou projetos
- Não altera backend
- Não altera banco de dados

## Banco de dados

Não houve alteração no banco.
`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Rodei `node --check script.js`
- [ ] Rodei `git diff --check`
- [ ] Testei mensagem de erro no login
- [ ] Testei feedback no mobile
- [ ] Conferi desktop rapidamente