### PR TITLE
style: reorganizar ficha tecnica do modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -628,6 +628,17 @@
             }
         }
 
+        function criarItemFicha(rotulo, valor) {
+            const valorLimpo = String(valor || '').trim();
+
+            return `
+                <div class="modal-ficha-item">
+                    <span>${textoFeedbackSeguro(rotulo)}</span>
+                    <strong>${textoFeedbackSeguro(valorLimpo || '---')}</strong>
+                </div>
+            `;
+        }
+
         function criarItemFichaOpcional(rotulo, valor) {
             const valorLimpo = String(valor || '').trim();
 
@@ -635,11 +646,24 @@
                 return '';
             }
 
+            return criarItemFicha(rotulo, valorLimpo);
+        }
+
+        function criarGrupoFichaTecnica(titulo, itens) {
+            const itensValidos = itens.filter(Boolean).join('');
+
+            if (!itensValidos) {
+                return '';
+            }
+
             return `
-                <div class="modal-item">
-                    <span>${textoFeedbackSeguro(rotulo)}</span>
-                    <strong>${textoFeedbackSeguro(valorLimpo)}</strong>
-                </div>
+                <section class="modal-ficha-grupo">
+                    <h3>${textoFeedbackSeguro(titulo)}</h3>
+
+                    <div class="modal-ficha-lista">
+                        ${itensValidos}
+                    </div>
+                </section>
             `;
         }
 
@@ -670,51 +694,40 @@
                 <div class="modal-info">
                     <h2>${carro.modelo} (${carro.ano})</h2>
 
-                    <div class="modal-grid">
-                        <div class="modal-item">
-                            <span>Proprietário</span>
-                            ${carro.usuario_id
-                                ? `<strong class="dono-link" onclick="abrirPerfil(${carro.usuario_id})">
-                                    ${carro.nome_dono}
-                                </strong>`
-                                : `<strong>${carro.nome_dono || '---'}</strong>`
-                            }
-                        </div>
+                    <div class="modal-ficha">
+                        ${criarGrupoFichaTecnica('Identificação', [
+                            `
+                                <div class="modal-ficha-item">
+                                    <span>Proprietário</span>
+                                    ${carro.usuario_id
+                                        ? `<strong class="dono-link" onclick="abrirPerfil(${carro.usuario_id})">
+                                            ${textoFeedbackSeguro(carro.nome_dono || '---')}
+                                        </strong>`
+                                        : `<strong>${textoFeedbackSeguro(carro.nome_dono || '---')}</strong>`
+                                    }
+                                </div>
+                            `,
+                            criarItemFicha('Ano', carro.ano),
+                            criarItemFicha('Cor', carro.cor),
+                            criarItemFichaOpcional('Placa', carro.placa)
+                        ])}
 
-                        <div class="modal-item">
-                            <span>Cor</span>
-                            <strong>${carro.cor}</strong>
-                        </div>
+                        ${criarGrupoFichaTecnica('Setup', [
+                            criarItemFichaOpcional('Motor', carro.motor),
+                            criarItemFichaOpcional('Câmbio', carro.cambio),
+                            criarItemFichaOpcional('Combustível', carro.combustivel)
+                        ])}
 
-                        <div class="modal-item">
-                            <span>Placa</span>
-                            <strong>${carro.placa || '---'}</strong>
-                        </div>
-
-                        <div class="modal-item">
-                            <span>Aro</span>
-                            <strong>${carro.aro_roda}</strong>
-                        </div>
-
-                        <div class="modal-item">
-                            <span>Suspensão</span>
-                            <strong>${carro.tipo_suspensao}</strong>
-                        </div>
-
-                        <div class="modal-item">
-                            <span>Ano</span>
-                            <strong>${carro.ano}</strong>
-                        </div>
-
-                        ${criarItemFichaOpcional('Motor', carro.motor)}
-                        ${criarItemFichaOpcional('Câmbio', carro.cambio)}
-                        ${criarItemFichaOpcional('Combustível', carro.combustivel)}
-                        ${criarItemFichaOpcional(
-                            'Potência estimada',
-                            carro.potencia_estimada ? `${carro.potencia_estimada} cv` : ''
-                        )}
-                        ${criarItemFichaOpcional('Preparação', carro.preparacao)}
-                        ${criarItemFichaOpcional('Status do projeto', carro.status_projeto)}
+                        ${criarGrupoFichaTecnica('Projeto', [
+                            criarItemFicha('Aro', carro.aro_roda),
+                            criarItemFicha('Suspensão', carro.tipo_suspensao),
+                            criarItemFichaOpcional(
+                                'Potência estimada',
+                                carro.potencia_estimada ? `${carro.potencia_estimada} cv` : ''
+                            ),
+                            criarItemFichaOpcional('Preparação', carro.preparacao),
+                            criarItemFichaOpcional('Status do projeto', carro.status_projeto)
+                        ])}
                     </div>
 
                     ${carro.historia ? `

--- a/style.css
+++ b/style.css
@@ -949,6 +949,65 @@
             margin-top: 22px;
         }
 
+        .modal-ficha {
+            display: grid;
+            gap: 14px;
+            margin: 22px 0 20px;
+        }
+
+        .modal-ficha-grupo {
+            padding: 14px 16px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: var(--radius-lg);
+            background:
+                linear-gradient(145deg, rgba(255, 255, 255, 0.035), transparent),
+                rgba(0, 0, 0, 0.18);
+        }
+
+        .modal-ficha-grupo h3 {
+            margin: 0 0 12px;
+            color: var(--accent);
+            font-size: 0.72rem;
+            font-weight: 950;
+            letter-spacing: 0.12em;
+            text-align: left;
+            text-transform: uppercase;
+        }
+
+        .modal-ficha-lista {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 8px;
+        }
+
+        .modal-ficha-item {
+            min-width: 0;
+            padding: 10px 12px;
+            border: 1px solid rgba(255, 255, 255, 0.075);
+            border-radius: var(--radius-md);
+            background: rgba(255, 255, 255, 0.035);
+        }
+
+        .modal-ficha-item span {
+            display: block;
+            margin-bottom: 5px;
+            color: var(--text-soft);
+            font-size: 0.64rem;
+            font-weight: 950;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .modal-ficha-item strong {
+            display: block;
+            color: var(--text-main);
+            font-size: 0.9rem;
+            font-weight: 900;
+            line-height: 1.25;
+            overflow-wrap: anywhere;
+            text-transform: uppercase;
+        }
+
         .modal-item {
             background:
                 linear-gradient(145deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012)),
@@ -4235,5 +4294,28 @@
                     border-radius: var(--radius-pill);
                     background: rgba(255, 255, 255, 0.035);
                     border-color: rgba(255, 255, 255, 0.12);
+                }
+
+                .modal-ficha {
+                    gap: 12px;
+                    margin: 18px 0 18px;
+                }
+
+                .modal-ficha-grupo {
+                    padding: 13px;
+                    border-radius: var(--radius-md);
+                }
+
+                .modal-ficha-lista {
+                    grid-template-columns: 1fr;
+                    gap: 8px;
+                }
+
+                .modal-ficha-item {
+                    padding: 10px 11px;
+                }
+
+                .modal-ficha-item strong {
+                    font-size: 0.86rem;
                 }
             }


### PR DESCRIPTION
closes #146

## Resumo

Reorganiza a ficha técnica exibida no modal de projeto, agrupando as informações por contexto e melhorando a leitura visual.

## Alterações

- Cria helpers para montar itens e grupos da ficha técnica
- Agrupa os dados em Identificação, Setup e Projeto
- Mantém todas as informações técnicas disponíveis
- Melhora a hierarquia visual da ficha no modal
- Ajusta o layout da ficha no desktop
- Ajusta a ficha para uma coluna no mobile

## Banco de dados

Não houve alteração no banco.

`garagem_digital.sql` não precisou ser alterado.

## Testes

- [ ] Rodei `node --check script.js`
- [ ] Rodei `git diff --check`
- [ ] Abri modal de projeto com ficha técnica completa
- [ ] Abri modal de projeto com campos opcionais vazios
- [ ] Conferi se todos os dados continuam aparecendo
- [ ] Conferi desktop
- [ ] Conferi mobile
- [ ] Conferi projeto vindo do feed
- [ ] Conferi projeto vindo do perfil, se possível
- [ ] Conferi projeto vindo de equipe, se possível