### PR TITLE
style: deixar comentarios recolhidos no modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -667,6 +667,54 @@
             `;
         }
 
+        function criarTextoToggleComentarios(aberto, total) {
+            const totalNormalizado = Number(total) || 0;
+
+            if (aberto) {
+                return 'Ocultar comentários';
+            }
+
+            if (totalNormalizado === 0) {
+                return 'Ver comentários';
+            }
+
+            if (totalNormalizado === 1) {
+                return 'Ver 1 comentário';
+            }
+
+            return `Ver ${totalNormalizado} comentários`;
+        }
+
+        function atualizarBotaoComentarios(total) {
+            const botao = document.getElementById('btn-toggle-comentarios');
+            const container = document.getElementById('comentarios-container');
+
+            if (!botao || !container) {
+                return;
+            }
+
+            const aberto = !container.classList.contains('comentarios-recolhidos');
+
+            botao.dataset.totalComentarios = total;
+            botao.innerText = criarTextoToggleComentarios(aberto, total);
+        }
+
+        function alternarComentariosProjeto(botao) {
+            const container = document.getElementById('comentarios-container');
+
+            if (!container || !botao) {
+                return;
+            }
+
+            const abrir = container.classList.contains('comentarios-recolhidos');
+
+            container.classList.toggle('comentarios-recolhidos', !abrir);
+            container.classList.toggle('comentarios-abertos', abrir);
+
+            const total = botao.dataset.totalComentarios || 0;
+            botao.innerText = criarTextoToggleComentarios(abrir, total);
+        }
+
         function abrirModalProjeto(carro, scrollManter = null) {
             const modal = document.getElementById('modal-projeto');
             const modalContent = document.getElementById('modal-content');
@@ -771,21 +819,38 @@
                         </div>
                     </div>
 
-                    <div class="comentarios-container" id="comentarios-container">
-                        <div class="comentarios-header">
-                            <h3>Comentários</h3>
+                    <div class="comentarios-container comentarios-recolhidos" id="comentarios-container">
+                        <div class="comentarios-header comentarios-header-recolhido">
+                            <div>
+                                <h3>Comentários</h3>
+                                <span class="comentarios-subtitulo">
+                                    Interações da comunidade sobre este projeto
+                                </span>
+                            </div>
 
                             <span class="comentarios-like ${curtido ? 'curtido' : ''}" onclick="curtirPeloModal(${carro.id})">
                                 👍 ${totalCurtidas} ${totalCurtidas === 1 ? 'curtida' : 'curtidas'}
                             </span>
                         </div>
 
-                        <div id="lista-comentarios"></div>
-
-                        <textarea id="input-comentario" placeholder="Escreva um comentário..."></textarea>
-                        <button type="button" class="btn-comentar" onclick="enviarComentario(${carro.id})">
-                            Comentar
+                        <button
+                            type="button"
+                            id="btn-toggle-comentarios"
+                            class="btn-toggle-comentarios"
+                            data-total-comentarios="${carro.total_comentarios || 0}"
+                            onclick="alternarComentariosProjeto(this)"
+                        >
+                            ${criarTextoToggleComentarios(false, carro.total_comentarios || 0)}
                         </button>
+
+                        <div class="comentarios-corpo" id="comentarios-corpo">
+                            <div id="lista-comentarios"></div>
+
+                            <textarea id="input-comentario" placeholder="Escreva um comentário..."></textarea>
+                            <button type="button" class="btn-comentar" onclick="enviarComentario(${carro.id})">
+                                Comentar
+                            </button>
+                        </div>
                     </div>
                 </div>
             `;
@@ -1289,6 +1354,8 @@
                 const lista = document.getElementById('lista-comentarios');
                 lista.innerHTML = '';
 
+                atualizarBotaoComentarios(comentarios.length);
+
                 if (!comentarios.length) {
                     lista.innerHTML = `<div style="color:#666;">Nenhum comentário ainda.</div>`;
                     return;
@@ -1296,16 +1363,19 @@
 
                 comentarios.forEach(c => {
                     const div = document.createElement('div');
+                    const autorComentario = c.username_usuario
+                        ? `@${c.username_usuario}`
+                        : c.nome_usuario;
 
                     div.innerHTML = `
                         <div class="comentario-item">
                             <div class="comentario-topo">
                                 ${c.usuario_id
                                     ? `<span class="comentario-autor" onclick="abrirPerfil(${c.usuario_id})">
-                                        ${c.nome_usuario}
+                                        ${textoFeedbackSeguro(autorComentario)}
                                     </span>`
                                     : `<span class="comentario-autor">
-                                        ${c.nome_usuario}
+                                        ${textoFeedbackSeguro(autorComentario)}
                                     </span>`
                                 }
 

--- a/style.css
+++ b/style.css
@@ -2660,6 +2660,73 @@
                 color: #ff6b78;
             }
 
+            .comentarios-header-recolhido {
+                align-items: flex-start;
+                margin-bottom: 12px;
+                padding-bottom: 12px;
+            }
+
+            .comentarios-header-recolhido h3 {
+                margin: 0 0 4px;
+                font-size: 1rem;
+                letter-spacing: -0.02em;
+                text-transform: none;
+            }
+
+            .comentarios-subtitulo {
+                display: block;
+                color: var(--text-muted);
+                font-size: 0.78rem;
+                line-height: 1.35;
+                text-transform: none;
+            }
+
+            .btn-toggle-comentarios {
+                width: 100%;
+                min-height: 44px;
+                margin: 0;
+                border-radius: var(--radius-pill);
+                background: rgba(255, 255, 255, 0.045);
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                color: var(--text-main);
+                font-size: 0.76rem;
+                font-weight: 950;
+                letter-spacing: 0.055em;
+                text-transform: uppercase;
+                box-shadow: none;
+            }
+
+            .btn-toggle-comentarios:hover {
+                background: rgba(255, 71, 87, 0.1);
+                border-color: rgba(255, 71, 87, 0.38);
+                color: #ff7a84;
+                transform: translateY(-1px);
+            }
+
+            .comentarios-corpo {
+                display: grid;
+                gap: 10px;
+                margin-top: 14px;
+            }
+
+            .comentarios-corpo #lista-comentarios {
+                margin-top: 0;
+            }
+
+            .comentarios-corpo #input-comentario {
+                margin-top: 0;
+            }
+
+            .comentarios-recolhidos .comentarios-corpo {
+                display: none;
+            }
+
+            .comentarios-abertos .btn-toggle-comentarios {
+                background: rgba(255, 71, 87, 0.12);
+                border-color: rgba(255, 71, 87, 0.42);
+                color: #ff7a84;
+            }
+
             .evolucao-container {
                 margin: 22px 0;
                 padding: 16px;
@@ -4483,5 +4550,26 @@
 
                 .evolucao-conteudo {
                     padding: 11px;
+                }
+
+                .comentarios-header-recolhido {
+                    flex-direction: column;
+                    align-items: flex-start;
+                    gap: 10px;
+                    margin-bottom: 10px;
+                    padding-bottom: 10px;
+                }
+
+                .comentarios-header-recolhido .comentarios-like {
+                    align-self: flex-start;
+                }
+
+                .btn-toggle-comentarios {
+                    min-height: 42px;
+                }
+
+                .comentarios-corpo {
+                    gap: 9px;
+                    margin-top: 12px;
                 }
             }


### PR DESCRIPTION
closes #150

## Resumo

Deixa os comentários do projeto recolhidos por padrão no modal, reduzindo a poluição visual e dando mais destaque à ficha técnica, história e diário de evolução.

## Alterações

- Mantém os comentários existentes
- Adiciona botão para abrir/fechar comentários
- Mostra a quantidade de comentários no botão
- Mantém curtidas visíveis no cabeçalho da seção
- Mantém formulário de comentário dentro da área aberta
- Atualiza o contador após carregar comentários
- Exibe o autor do comentário como @usuario quando disponível
- Ajusta o visual no mobile

## Banco de dados

Não houve alteração no banco.

`garagem_digital.sql` não precisou ser alterado.

## Testes

- `node --check script.js`
- `git diff --check`
- Testado visualmente no navegador
- Testado abrir/fechar comentários no modal
- Testado exibição de @usuario nos comentários