### PR TITLE
feat: iniciar tela dedicada de projeto

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,9 @@
         <div class="galeria" id="lista-carros"></div>
     </div>
 
+    <!-- Tela dedicada de projeto -->
+    <section id="tela-projeto" class="tela-projeto" style="display: none;"></section>
+
     <!-- Modal de projeto -->
     <div id="modal-projeto" class="modal">
         <div class="modal-content" id="modal-content"></div>

--- a/script.js
+++ b/script.js
@@ -556,7 +556,7 @@
                         donoLink.onclick = () => abrirPerfil(donoLink.dataset.id);
                     }
 
-                    card.querySelector('.btn-ver').onclick = () => abrirModalProjeto(carro);
+                    card.querySelector('.btn-ver').onclick = () => abrirTelaProjeto(carro);
 
                     const likeBtn = card.querySelector('.like-btn');
 
@@ -667,6 +667,46 @@
             `;
         }
 
+        function criarHtmlFichaProjeto(carro) {
+            return `
+                <div class="modal-ficha">
+                    ${criarGrupoFichaTecnica('Identificação', [
+                        `
+                            <div class="modal-ficha-item">
+                                <span>Proprietário</span>
+                                ${carro.usuario_id
+                                    ? `<strong class="dono-link" onclick="abrirPerfil(${carro.usuario_id})">
+                                        ${textoFeedbackSeguro(carro.nome_dono || '---')}
+                                    </strong>`
+                                    : `<strong>${textoFeedbackSeguro(carro.nome_dono || '---')}</strong>`
+                                }
+                            </div>
+                        `,
+                        criarItemFicha('Ano', carro.ano),
+                        criarItemFicha('Cor', carro.cor),
+                        criarItemFichaOpcional('Placa', carro.placa)
+                    ])}
+
+                    ${criarGrupoFichaTecnica('Setup', [
+                        criarItemFichaOpcional('Motor', carro.motor),
+                        criarItemFichaOpcional('Câmbio', carro.cambio),
+                        criarItemFichaOpcional('Combustível', carro.combustivel)
+                    ])}
+
+                    ${criarGrupoFichaTecnica('Projeto', [
+                        criarItemFicha('Aro', carro.aro_roda),
+                        criarItemFicha('Suspensão', carro.tipo_suspensao),
+                        criarItemFichaOpcional(
+                            'Potência estimada',
+                            carro.potencia_estimada ? `${carro.potencia_estimada} cv` : ''
+                        ),
+                        criarItemFichaOpcional('Preparação', carro.preparacao),
+                        criarItemFichaOpcional('Status do projeto', carro.status_projeto)
+                    ])}
+                </div>
+            `;
+        }
+
         function criarTextoToggleComentarios(aberto, total) {
             const totalNormalizado = Number(total) || 0;
 
@@ -715,6 +755,48 @@
             botao.innerText = criarTextoToggleComentarios(abrir, total);
         }
 
+        function criarBlocoComentariosProjeto(carro) {
+            const totalCurtidas = carro.total_curtidas || 0;
+            const curtido = estaCurtido(carro.curtido_pelo_usuario);
+            const totalComentarios = carro.total_comentarios || 0;
+
+            return `
+                <div class="comentarios-container comentarios-recolhidos" id="comentarios-container">
+                    <div class="comentarios-header comentarios-header-recolhido">
+                        <div>
+                            <h3>Comentários</h3>
+                            <span class="comentarios-subtitulo">
+                                Interações da comunidade sobre este projeto
+                            </span>
+                        </div>
+
+                        <span class="comentarios-like ${curtido ? 'curtido' : ''}" onclick="curtirPeloModal(${carro.id})">
+                            👍 ${totalCurtidas} ${totalCurtidas === 1 ? 'curtida' : 'curtidas'}
+                        </span>
+                    </div>
+
+                    <button
+                        type="button"
+                        id="btn-toggle-comentarios"
+                        class="btn-toggle-comentarios"
+                        data-total-comentarios="${totalComentarios}"
+                        onclick="alternarComentariosProjeto(this)"
+                    >
+                        ${criarTextoToggleComentarios(false, totalComentarios)}
+                    </button>
+
+                    <div class="comentarios-corpo" id="comentarios-corpo">
+                        <div id="lista-comentarios"></div>
+
+                        <textarea id="input-comentario" placeholder="Escreva um comentário..."></textarea>
+                        <button type="button" class="btn-comentar" onclick="enviarComentario(${carro.id})">
+                            Comentar
+                        </button>
+                    </div>
+                </div>
+            `;
+        }
+
         function abrirModalProjeto(carro, scrollManter = null) {
             const modal = document.getElementById('modal-projeto');
             const modalContent = document.getElementById('modal-content');
@@ -743,41 +825,7 @@
                 <div class="modal-info">
                     <h2>${carro.modelo} (${carro.ano})</h2>
 
-                    <div class="modal-ficha">
-                        ${criarGrupoFichaTecnica('Identificação', [
-                            `
-                                <div class="modal-ficha-item">
-                                    <span>Proprietário</span>
-                                    ${carro.usuario_id
-                                        ? `<strong class="dono-link" onclick="abrirPerfil(${carro.usuario_id})">
-                                            ${textoFeedbackSeguro(carro.nome_dono || '---')}
-                                        </strong>`
-                                        : `<strong>${textoFeedbackSeguro(carro.nome_dono || '---')}</strong>`
-                                    }
-                                </div>
-                            `,
-                            criarItemFicha('Ano', carro.ano),
-                            criarItemFicha('Cor', carro.cor),
-                            criarItemFichaOpcional('Placa', carro.placa)
-                        ])}
-
-                        ${criarGrupoFichaTecnica('Setup', [
-                            criarItemFichaOpcional('Motor', carro.motor),
-                            criarItemFichaOpcional('Câmbio', carro.cambio),
-                            criarItemFichaOpcional('Combustível', carro.combustivel)
-                        ])}
-
-                        ${criarGrupoFichaTecnica('Projeto', [
-                            criarItemFicha('Aro', carro.aro_roda),
-                            criarItemFicha('Suspensão', carro.tipo_suspensao),
-                            criarItemFichaOpcional(
-                                'Potência estimada',
-                                carro.potencia_estimada ? `${carro.potencia_estimada} cv` : ''
-                            ),
-                            criarItemFichaOpcional('Preparação', carro.preparacao),
-                            criarItemFichaOpcional('Status do projeto', carro.status_projeto)
-                        ])}
-                    </div>
+                    ${criarHtmlFichaProjeto(carro)}
 
                     ${carro.historia ? `
                         <div class="historia-projeto">
@@ -819,7 +867,7 @@
                         </div>
                     </div>
 
-                    <div class="comentarios-container comentarios-recolhidos" id="comentarios-container">
+                    ${criarBlocoComentariosProjeto(carro)}
                         <div class="comentarios-header comentarios-header-recolhido">
                             <div>
                                 <h3>Comentários</h3>
@@ -871,8 +919,111 @@
             }, 100);
         }
 
-        async function carregarEvolucoes(carroId) {
-            const lista = document.getElementById('lista-evolucoes');
+        function abrirTelaProjeto(carro) {
+            const tela = document.getElementById('tela-projeto');
+            const conteudoApp = document.getElementById('conteudo-app');
+
+            if (!tela) {
+                abrirModalProjeto(carro);
+                return;
+            }
+
+            const img = carro.foto_url ? `${API_URL}/uploads/${carro.foto_url}` : '';
+            const dono = usuarioEDono(carro);
+            const historia = String(carro.historia || '').trim();
+
+            tela.innerHTML = `
+                <div class="pagina-projeto">
+                    <div class="pagina-projeto-topbar">
+                        <button type="button" class="btn-voltar-projeto" onclick="fecharTelaProjeto()">
+                            ← Voltar para garagem
+                        </button>
+
+                        ${dono ? '<span class="pagina-projeto-badge">Seu projeto</span>' : ''}
+                    </div>
+
+                    <section class="pagina-projeto-hero">
+                        ${img
+                            ? `<img src="${img}" class="pagina-projeto-img">`
+                            : '<div class="pagina-projeto-sem-foto">Sem foto</div>'
+                        }
+
+                        <div class="pagina-projeto-hero-info">
+                            <span class="pagina-projeto-kicker">Projeto automotivo</span>
+                            <h2>${textoFeedbackSeguro(carro.modelo)} (${textoFeedbackSeguro(carro.ano)})</h2>
+                        </div>
+                    </section>
+
+                    <div class="pagina-projeto-conteudo">
+                        ${criarHtmlFichaProjeto(carro)}
+
+                        <section class="pagina-projeto-bloco">
+                            <h3>História do projeto</h3>
+                            <p>${historia ? textoFeedbackSeguro(historia) : 'Ainda não adicionada.'}</p>
+                        </section>
+
+                        <section class="pagina-projeto-bloco">
+                            <div class="evolucao-header">
+                                <div>
+                                    <h3>Diário de evolução</h3>
+                                    <span>Últimas atualizações, mudanças e fases do projeto</span>
+                                </div>
+                            </div>
+
+                            <div id="lista-evolucoes-tela" class="evolucao-lista">
+                                <div class="evolucao-vazio">Carregando evolução do projeto...</div>
+                            </div>
+                        </section>
+
+                        ${criarBlocoComentariosProjeto(carro)}
+
+                    </div>
+                </div>
+            `;
+
+            if (conteudoApp) {
+                conteudoApp.style.display = 'none';
+            }
+
+            tela.style.display = 'block';
+            document.body.classList.add('tela-projeto-aberta');
+
+            window.scrollTo({
+                top: 0,
+                left: 0,
+                behavior: 'auto'
+            });
+
+            setTimeout(() => {
+                carregarEvolucoes(carro.id, 'lista-evolucoes-tela');
+                carregarComentarios(carro.id);
+            }, 100);
+        }
+
+        function fecharTelaProjeto() {
+            const tela = document.getElementById('tela-projeto');
+            const conteudoApp = document.getElementById('conteudo-app');
+
+            if (tela) {
+                tela.style.display = 'none';
+                tela.innerHTML = '';
+            }
+
+            if (conteudoApp) {
+                conteudoApp.style.display = 'block';
+            }
+
+            document.body.classList.remove('tela-projeto-aberta');
+
+            window.scrollTo({
+                top: 0,
+                left: 0,
+                behavior: 'auto'
+            });
+        }
+
+        async function carregarEvolucoes(carroId, listaId = 'lista-evolucoes') {
+            const lista = document.getElementById(listaId);
 
             if (!lista) {
                 return;

--- a/script.js
+++ b/script.js
@@ -810,8 +810,6 @@
             document.body.style.overflow = "hidden";
 
             const img = carro.foto_url ? `${API_URL}/uploads/${carro.foto_url}` : '';
-            const totalCurtidas = carro.total_curtidas || 0;
-            const curtido = estaCurtido(carro.curtido_pelo_usuario);
             const dono = usuarioEDono(carro);
 
             modalContent.innerHTML = `
@@ -868,38 +866,7 @@
                     </div>
 
                     ${criarBlocoComentariosProjeto(carro)}
-                        <div class="comentarios-header comentarios-header-recolhido">
-                            <div>
-                                <h3>Comentários</h3>
-                                <span class="comentarios-subtitulo">
-                                    Interações da comunidade sobre este projeto
-                                </span>
-                            </div>
 
-                            <span class="comentarios-like ${curtido ? 'curtido' : ''}" onclick="curtirPeloModal(${carro.id})">
-                                👍 ${totalCurtidas} ${totalCurtidas === 1 ? 'curtida' : 'curtidas'}
-                            </span>
-                        </div>
-
-                        <button
-                            type="button"
-                            id="btn-toggle-comentarios"
-                            class="btn-toggle-comentarios"
-                            data-total-comentarios="${carro.total_comentarios || 0}"
-                            onclick="alternarComentariosProjeto(this)"
-                        >
-                            ${criarTextoToggleComentarios(false, carro.total_comentarios || 0)}
-                        </button>
-
-                        <div class="comentarios-corpo" id="comentarios-corpo">
-                            <div id="lista-comentarios"></div>
-
-                            <textarea id="input-comentario" placeholder="Escreva um comentário..."></textarea>
-                            <button type="button" class="btn-comentar" onclick="enviarComentario(${carro.id})">
-                                Comentar
-                            </button>
-                        </div>
-                    </div>
                 </div>
             `;
 

--- a/style.css
+++ b/style.css
@@ -2727,6 +2727,173 @@
                 color: #ff7a84;
             }
 
+            body.tela-projeto-aberta > h1 {
+                display: none;
+            }
+
+            .tela-projeto {
+                max-width: 980px;
+                margin: 0 auto;
+            }
+
+            .pagina-projeto {
+                display: grid;
+                gap: 18px;
+            }
+
+            .pagina-projeto-topbar {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 12px;
+                margin-bottom: 4px;
+            }
+
+            .btn-voltar-projeto {
+                width: auto;
+                min-height: 42px;
+                margin: 0;
+                padding: 10px 16px;
+                border-radius: var(--radius-pill);
+                background: rgba(255, 255, 255, 0.045);
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                color: var(--text-main);
+                font-size: 0.76rem;
+                font-weight: 950;
+                letter-spacing: 0.055em;
+                text-transform: uppercase;
+                box-shadow: none;
+            }
+
+            .pagina-projeto-badge {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                min-height: 34px;
+                padding: 7px 12px;
+                border-radius: var(--radius-pill);
+                background: rgba(255, 71, 87, 0.13);
+                border: 1px solid rgba(255, 71, 87, 0.28);
+                color: #ff7a84;
+                font-size: 0.68rem;
+                font-weight: 950;
+                letter-spacing: 0.075em;
+                text-transform: uppercase;
+            }
+
+            .pagina-projeto-hero {
+                overflow: hidden;
+                border: 1px solid var(--border-glass);
+                border-radius: var(--radius-xl);
+                background:
+                    radial-gradient(circle at top left, rgba(255, 71, 87, 0.13), transparent 34%),
+                    linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent),
+                    rgba(15, 15, 15, 0.96);
+                box-shadow: var(--shadow-premium);
+            }
+
+            .pagina-projeto-img,
+            .pagina-projeto-sem-foto {
+                width: 100%;
+                height: 430px;
+            }
+
+            .pagina-projeto-img {
+                display: block;
+                object-fit: cover;
+                filter: brightness(0.94) contrast(1.1) saturate(1.08);
+            }
+
+            .pagina-projeto-sem-foto {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                color: rgba(255, 255, 255, 0.28);
+                background:
+                    radial-gradient(circle at center, rgba(255, 71, 87, 0.12), transparent 38%),
+                    #050505;
+                font-size: 0.82rem;
+                font-weight: 950;
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
+            }
+
+            .pagina-projeto-hero-info {
+                padding: 24px;
+            }
+
+            .pagina-projeto-kicker {
+                display: block;
+                margin-bottom: 8px;
+                color: var(--accent);
+                font-size: 0.7rem;
+                font-weight: 950;
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
+            }
+
+            .pagina-projeto-hero-info h2 {
+                margin: 0 0 12px;
+                color: var(--text-main);
+                font-size: clamp(1.8rem, 5vw, 3rem);
+                font-weight: 950;
+                line-height: 1;
+                letter-spacing: -0.06em;
+                text-align: left;
+                text-transform: uppercase;
+            }
+
+            .pagina-projeto-dono {
+                width: auto;
+                min-height: auto;
+                margin: 0;
+                padding: 0;
+                background: transparent;
+                border: 0;
+                color: var(--text-muted);
+                font-size: 0.9rem;
+                font-weight: 850;
+                text-align: left;
+                text-transform: none;
+                box-shadow: none;
+            }
+
+            .pagina-projeto-conteudo {
+                display: grid;
+                gap: 18px;
+            }
+
+            .pagina-projeto .modal-ficha {
+                margin: 0;
+            }
+
+            .pagina-projeto-bloco {
+                padding: 18px;
+                border: 1px solid rgba(255, 255, 255, 0.08);
+                border-radius: var(--radius-lg);
+                background:
+                    linear-gradient(145deg, rgba(255, 255, 255, 0.035), transparent),
+                    rgba(0, 0, 0, 0.18);
+            }
+
+            .pagina-projeto-bloco h3 {
+                margin: 0 0 10px;
+                color: var(--text-main);
+                font-size: 1rem;
+                font-weight: 950;
+                letter-spacing: -0.02em;
+                text-align: left;
+                text-transform: none;
+            }
+
+            .pagina-projeto-bloco p {
+                margin: 0;
+                color: var(--text-muted);
+                font-size: 0.92rem;
+                line-height: 1.55;
+                text-transform: none;
+            }
+
             .evolucao-container {
                 margin: 22px 0;
                 padding: 16px;
@@ -4571,5 +4738,52 @@
                 .comentarios-corpo {
                     gap: 9px;
                     margin-top: 12px;
+                }
+
+                .tela-projeto {
+                    max-width: 520px;
+                    margin: 0 auto;
+                }
+
+                .pagina-projeto {
+                    gap: 14px;
+                }
+
+                .pagina-projeto-topbar {
+                    align-items: flex-start;
+                }
+
+                .btn-voltar-projeto {
+                    min-height: 40px;
+                    padding: 9px 13px;
+                    font-size: 0.68rem;
+                }
+
+                .pagina-projeto-badge {
+                    min-height: 30px;
+                    padding: 6px 10px;
+                    font-size: 0.6rem;
+                }
+
+                .pagina-projeto-hero {
+                    border-radius: var(--radius-xl);
+                }
+
+                .pagina-projeto-img,
+                .pagina-projeto-sem-foto {
+                    height: 300px;
+                }
+
+                .pagina-projeto-hero-info {
+                    padding: 18px;
+                }
+
+                .pagina-projeto-hero-info h2 {
+                    font-size: 2rem;
+                }
+
+                .pagina-projeto-bloco {
+                    padding: 14px;
+                    border-radius: var(--radius-md);
                 }
             }


### PR DESCRIPTION
closes #152 

## O que foi feito

- Cria uma tela dedicada para visualizar um projeto automotivo.
- Adiciona estrutura inicial de página própria para projeto.
- Mantém botão de voltar para a garagem.
- Exibe imagem principal, título, ficha técnica, história, diário de evolução e comentários.
- Reaproveita componentes já existentes do modal para evitar refatoração grande.
- Mantém comentários recolhidos inicialmente para não poluir a tela do projeto.

## Observações

Esta PR cria a base da tela dedicada de projeto. O visual ainda poderá ser refinado em issues futuras, principalmente com abas, hero mais premium e melhor hierarquia visual.

## Banco de dados

Esta alteração não modifica a estrutura do banco de dados, então o arquivo `garagem_digital.sql` não precisou ser alterado.