### PR TITLE
style: refina topo mobile da tela de projeto

### DIFF
--- a/style.css
+++ b/style.css
@@ -5172,76 +5172,161 @@
                 .tela-projeto {
                     max-width: 520px;
                     margin: 0 auto;
+                    padding-bottom: 18px;
                 }
 
                 .pagina-projeto {
-                    gap: 14px;
+                    gap: 13px;
                 }
 
                 .pagina-projeto-topbar {
-                    align-items: flex-start;
+                    flex-direction: column;
+                    align-items: stretch;
+                    gap: 8px;
                 }
 
                 .btn-voltar-projeto {
-                    min-height: 40px;
-                    padding: 9px 13px;
+                    width: 100%;
+                    min-height: 42px;
+                    justify-content: center;
+                    padding: 10px 13px;
                     font-size: 0.66rem;
                 }
 
                 .pagina-projeto-badge {
-                    min-height: 30px;
+                    width: fit-content;
+                    min-height: 28px;
+                    align-self: flex-start;
+                    margin-right: 0;
                     padding: 6px 10px;
-                    font-size: 0.6rem;
+                    font-size: 0.58rem;
                 }
 
                 .pagina-projeto-hero {
-                    min-height: 430px;
-                    border-radius: 26px;
+                    min-height: 365px;
+                    border-radius: 24px;
+                }
+
+                .pagina-projeto-hero::after {
+                    background:
+                        linear-gradient(180deg, transparent 20%, rgba(0, 0, 0, 0.28) 48%, rgba(0, 0, 0, 0.9) 100%),
+                        radial-gradient(circle at bottom left, rgba(255, 71, 87, 0.18), transparent 34%);
                 }
 
                 .pagina-projeto-hero-info {
-                    padding: 22px 18px;
+                    width: 100%;
+                    padding: 24px 18px 20px;
                 }
 
                 .pagina-projeto-kicker {
-                    margin-bottom: 9px;
-                    padding: 6px 10px;
-                    font-size: 0.6rem;
+                    margin-bottom: 8px;
+                    padding: 6px 9px;
+                    font-size: 0.58rem;
+                    letter-spacing: 0.1em;
                 }
 
                 .pagina-projeto-hero-info h2 {
-                    font-size: clamp(2.15rem, 14vw, 3.15rem);
-                    line-height: 0.94;
+                    font-size: clamp(1.9rem, 12.2vw, 2.85rem);
+                    line-height: 0.96;
+                    letter-spacing: -0.07em;
                 }
 
                 .pagina-projeto-conteudo {
-                    gap: 14px;
+                    gap: 13px;
                 }
 
                 .pagina-projeto-tabs {
-                    top: 10px;
-                    gap: 5px;
+                    top: 8px;
+                    gap: 4px;
                     padding: 5px;
-                    border-radius: var(--radius-lg);
+                    border-radius: 20px;
+                    box-shadow: 0 14px 34px rgba(0, 0, 0, 0.38);
                 }
 
                 .pagina-projeto-tab {
-                    min-height: 40px;
-                    padding: 9px 6px;
-                    font-size: 0.62rem;
-                    letter-spacing: 0.04em;
+                    min-height: 38px;
+                    padding: 8px 4px;
+                    font-size: 0.58rem;
+                    letter-spacing: 0.035em;
                 }
 
                 .pagina-projeto-painel.ativo {
-                    gap: 14px;
+                    gap: 13px;
+                }
+
+                .pagina-projeto .modal-ficha {
+                    gap: 11px;
+                }
+
+                .pagina-projeto .modal-ficha-grupo,
+                .pagina-projeto-bloco,
+                .pagina-projeto .comentarios-container {
+                    border-radius: 20px;
+                    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.34);
+                }
+
+                .pagina-projeto .modal-ficha-grupo {
+                    padding: 13px;
+                }
+
+                .pagina-projeto .modal-ficha-lista {
+                    gap: 7px;
+                }
+
+                .pagina-projeto .modal-ficha-item {
+                    padding: 9px 10px;
+                    border-radius: 14px;
+                }
+
+                .pagina-projeto .modal-ficha-item span {
+                    font-size: 0.58rem;
+                }
+
+                .pagina-projeto .modal-ficha-item strong {
+                    font-size: 0.82rem;
+                    line-height: 1.22;
                 }
 
                 .pagina-projeto-bloco {
                     padding: 14px;
-                    border-radius: var(--radius-md);
+                    border-radius: 20px;
+                }
+
+                .pagina-projeto-bloco h3 {
+                    margin-bottom: 8px;
+                    font-size: 0.96rem;
                 }
 
                 .pagina-projeto-bloco p {
-                    font-size: 0.86rem;
+                    font-size: 0.84rem;
+                    line-height: 1.55;
+                }
+
+                .pagina-projeto .evolucao-header {
+                    margin-bottom: 12px;
+                }
+
+                .pagina-projeto .evolucao-header span {
+                    font-size: 0.74rem;
+                }
+
+                .pagina-projeto .evolucao-lista {
+                    gap: 10px;
+                }
+
+                .pagina-projeto .evolucao-item {
+                    grid-template-columns: 13px 1fr;
+                    gap: 7px;
+                }
+
+                .pagina-projeto .evolucao-ponto {
+                    width: 8px;
+                    height: 8px;
+                    box-shadow: 0 0 0 4px rgba(255, 71, 87, 0.12);
+                }
+
+                .pagina-projeto .evolucao-conteudo {
+                    padding: 10px;
+                    border-radius: 14px;
                 }
             }


### PR DESCRIPTION
closes #164 

## O que foi feito

- Ajusta a organização do topo da tela dedicada de projeto no mobile.
- Melhora o espaçamento entre barra do usuário, botão de voltar e selo "Seu projeto".
- Evita sobreposição visual entre os elementos do topo.
- Mantém a tela preparada para uma futura reformulação da barra de perfil.

## Observação

Não houve alteração estrutural no banco.
O arquivo `garagem_digital.sql` não precisou ser alterado.