### PR TITLE
style: refina cards mobile da tela de projeto

### DIFF
--- a/style.css
+++ b/style.css
@@ -5287,6 +5287,31 @@
                     line-height: 1.22;
                 }
 
+                .pagina-projeto .modal-ficha-grupo h3 {
+                    margin-bottom: 12px;
+                    font-size: 0.7rem;
+                    letter-spacing: 0.14em;
+                }
+
+                .pagina-projeto .modal-ficha-lista {
+                    gap: 8px;
+                }
+
+                .pagina-projeto .modal-ficha-item {
+                    background:
+                        linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent),
+                        rgba(255, 255, 255, 0.018);
+                }
+
+                .pagina-projeto .modal-ficha-item span {
+                    margin-bottom: 5px;
+                    letter-spacing: 0.1em;
+                }
+
+                .pagina-projeto .modal-ficha-item strong {
+                    font-size: 0.84rem;
+                }
+
                 .pagina-projeto-bloco {
                     padding: 14px;
                     border-radius: 20px;


### PR DESCRIPTION
closes #166 

## Resumo

Refina o visual mobile da tela dedicada de projeto, melhorando a apresentação dos cards e a leitura geral da página em telas menores.

## Alterações

- Ajusta espaçamentos e proporções dos blocos no mobile
- Melhora a organização visual dos cards da ficha do projeto
- Refina a experiência da tela dedicada em largura reduzida
- Mantém a mudança limitada ao CSS da tela de projeto

## Observação

A barra de perfil será repensada em uma melhoria futura.