### PR TITLE
feat: adiciona galeria de fotos aos projetos

### DIFF
--- a/app.py
+++ b/app.py
@@ -778,6 +778,132 @@ def cadastrar_evolucao_projeto(id):
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
 
+@app.route('/carros/<int:id>/fotos', methods=['GET'])
+def listar_fotos_projeto(id):
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        cursor.execute("SELECT id FROM carros WHERE id = %s", (id,))
+        carro = cursor.fetchone()
+
+        if not carro:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Projeto não encontrado."}), 404
+
+        cursor.execute(
+            """
+            SELECT
+                id,
+                carro_id,
+                usuario_id,
+                imagem_url,
+                legenda,
+                criado_em
+            FROM fotos_projeto
+            WHERE carro_id = %s
+            ORDER BY criado_em DESC, id DESC
+            """,
+            (id,)
+        )
+
+        fotos = cursor.fetchall()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify(fotos), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
+
+@app.route('/carros/<int:id>/fotos', methods=['POST'])
+def cadastrar_foto_projeto(id):
+    usuario_id = str(request.form.get('usuario_id', '')).strip()
+    legenda = str(request.form.get('legenda', '')).strip()
+
+    if not usuario_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    if len(legenda) > 120:
+        return jsonify({"erro": "A legenda deve ter no máximo 120 caracteres."}), 400
+
+    foto = request.files.get('foto')
+
+    if not foto or foto.filename == "":
+        return jsonify({"erro": "Escolha uma imagem para adicionar à galeria."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, usuario_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário inválido."}), 403
+
+        cursor.execute(
+            """
+            SELECT id, usuario_id
+            FROM carros
+            WHERE id = %s
+            """,
+            (id,)
+        )
+
+        carro = cursor.fetchone()
+
+        if not carro:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Projeto não encontrado."}), 404
+
+        if str(carro['usuario_id']) != usuario_id:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Você não tem permissão para adicionar fotos neste projeto."}), 403
+
+        nome_foto = salvar_imagem(foto)
+
+        cursor.execute(
+            """
+            INSERT INTO fotos_projeto (carro_id, usuario_id, imagem_url, legenda)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (
+                id,
+                usuario_id,
+                nome_foto,
+                legenda if legenda else None
+            )
+        )
+
+        conexao.commit()
+
+        foto_id = cursor.lastrowid
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify({
+            "mensagem": "Foto adicionada à galeria!",
+            "foto": {
+                "id": foto_id,
+                "carro_id": id,
+                "usuario_id": usuario_id,
+                "imagem_url": nome_foto,
+                "legenda": legenda
+            }
+        }), 201
+
+    except ValueError as e:
+        return jsonify({"erro": str(e)}), 400
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
 @app.route('/usuarios/<int:id>', methods=['GET'])
 def buscar_usuario(id):
     usuario_logado_id = request.args.get('usuario_logado_id')

--- a/garagem_digital.sql
+++ b/garagem_digital.sql
@@ -14,6 +14,7 @@ DROP TABLE IF EXISTS seguidores;
 DROP TABLE IF EXISTS evolucoes_projeto;
 DROP TABLE IF EXISTS comentarios;
 DROP TABLE IF EXISTS curtidas;
+DROP TABLE IF EXISTS fotos_projeto;
 DROP TABLE IF EXISTS carros;
 DROP TABLE IF EXISTS usuarios;
 
@@ -53,6 +54,24 @@ CREATE TABLE carros (
     CONSTRAINT fk_carros_usuarios
         FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
         ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE fotos_projeto (
+    id INT NOT NULL AUTO_INCREMENT,
+    carro_id INT NOT NULL,
+    usuario_id INT NOT NULL,
+    imagem_url VARCHAR(255) NOT NULL,
+    legenda VARCHAR(120),
+    criado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_fotos_projeto_carro (carro_id),
+    KEY idx_fotos_projeto_usuario (usuario_id),
+    CONSTRAINT fk_fotos_projeto_carros
+        FOREIGN KEY (carro_id) REFERENCES carros(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_fotos_projeto_usuarios
+        FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
+        ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 CREATE TABLE curtidas (

--- a/script.js
+++ b/script.js
@@ -1043,6 +1043,16 @@
                             <button
                                 type="button"
                                 class="pagina-projeto-tab"
+                                data-aba="galeria"
+                                aria-selected="false"
+                                onclick="alternarAbaProjeto('galeria')"
+                            >
+                                Galeria
+                            </button>
+
+                            <button
+                                type="button"
+                                class="pagina-projeto-tab"
                                 data-aba="diario"
                                 aria-selected="false"
                                 onclick="alternarAbaProjeto('diario')"
@@ -1067,6 +1077,47 @@
                             <section class="pagina-projeto-bloco">
                                 <h3>História do projeto</h3>
                                 <p>${historia ? textoFeedbackSeguro(historia) : 'Ainda não adicionada.'}</p>
+                            </section>
+                        </section>
+
+                        <section class="pagina-projeto-painel" data-painel="galeria">
+                            <section class="pagina-projeto-bloco galeria-projeto-bloco">
+                                <div class="galeria-projeto-header">
+                                    <div>
+                                        <h3>Galeria do projeto</h3>
+                                        <span>Fotos extras, detalhes e registros visuais da garagem</span>
+                                    </div>
+                                </div>
+
+                                ${dono ? `
+                                    <form class="galeria-projeto-form" onsubmit="enviarFotoGaleria(event, ${carro.id})">
+                                        <label class="upload-container">
+                                            <span class="upload-btn">Escolher foto</span>
+                                            <span class="upload-nome" id="galeria-foto-nome">Nenhum arquivo</span>
+
+                                            <input
+                                                type="file"
+                                                id="galeria-foto-input"
+                                                accept="image/png, image/jpeg, image/webp"
+                                            >
+                                        </label>
+
+                                        <input
+                                            type="text"
+                                            id="galeria-legenda-input"
+                                            placeholder="Legenda opcional"
+                                            maxlength="120"
+                                        >
+
+                                        <button type="submit" class="btn-galeria-projeto">
+                                            Adicionar à galeria
+                                        </button>
+                                    </form>
+                                ` : ''}
+
+                                <div id="galeria-projeto-lista" class="galeria-projeto-lista">
+                                    <div class="galeria-projeto-vazio">Carregando galeria...</div>
+                                </div>
                             </section>
                         </section>
 
@@ -1106,6 +1157,7 @@
             });
 
             setTimeout(() => {
+                carregarGaleriaProjeto(carro.id, dono);
                 carregarEvolucoes(carro.id, 'lista-evolucoes-tela');
                 carregarComentarios(carro.id);
             }, 100);
@@ -1131,6 +1183,148 @@
                 left: 0,
                 behavior: 'auto'
             });
+        }
+
+        async function carregarGaleriaProjeto(carroId, dono = false) {
+            const lista = document.getElementById('galeria-projeto-lista');
+
+            if (!lista) {
+                return;
+            }
+
+            try {
+                const res = await fetch(`${API_URL}/carros/${carroId}/fotos`);
+                const fotos = await res.json();
+
+                if (!res.ok) {
+                    console.error("Erro ao carregar galeria:", fotos);
+                    lista.innerHTML = '<div class="galeria-projeto-vazio">Não foi possível carregar a galeria.</div>';
+                    return;
+                }
+
+                if (!Array.isArray(fotos) || fotos.length === 0) {
+                    lista.innerHTML = dono
+                        ? '<div class="galeria-projeto-vazio">Sua galeria ainda está vazia. Adicione fotos extras do projeto.</div>'
+                        : '<div class="galeria-projeto-vazio">Este projeto ainda não tem fotos na galeria.</div>';
+
+                    return;
+                }
+
+                lista.innerHTML = fotos.map(foto => {
+                    const src = foto.imagem_url ? `${API_URL}/uploads/${foto.imagem_url}` : '';
+                    const legenda = String(foto.legenda || '').trim();
+
+                    return `
+                        <article class="galeria-projeto-card">
+                            ${src
+                                ? `<img src="${src}" alt="Foto da galeria do projeto">`
+                                : '<div class="galeria-projeto-sem-foto">Sem foto</div>'
+                            }
+
+                            <div class="galeria-projeto-info">
+                                <strong>${legenda ? textoFeedbackSeguro(legenda) : 'Registro do projeto'}</strong>
+                                <span>${formatarTempoRelativo(foto.criado_em)}</span>
+                            </div>
+                        </article>
+                    `;
+                }).join('');
+
+            } catch (error) {
+                lista.innerHTML = '<div class="galeria-projeto-vazio">Erro ao carregar a galeria.</div>';
+                console.error("Falha inesperada ao carregar galeria:", error);
+            }
+        }
+
+
+        async function enviarFotoGaleria(event, carroId) {
+            event.preventDefault();
+
+            const usuario = getUsuarioLogado();
+
+            if (!usuario) {
+                mostrarMensagem("Faça login para adicionar fotos à galeria.", "aviso");
+                return;
+            }
+
+            const inputFoto = document.getElementById('galeria-foto-input');
+            const inputLegenda = document.getElementById('galeria-legenda-input');
+            const botao = event.target.querySelector('button[type="submit"]');
+
+            const foto = inputFoto && inputFoto.files.length > 0
+                ? inputFoto.files[0]
+                : null;
+
+            const legenda = inputLegenda ? inputLegenda.value.trim() : '';
+
+            if (!foto) {
+                mostrarMensagem("Escolha uma foto para adicionar à galeria.", "aviso");
+                return;
+            }
+
+            const tamanhoMaximoImagem = 5 * 1024 * 1024;
+            const formatosPermitidos = ['image/png', 'image/jpeg', 'image/webp'];
+            const extensoesPermitidas = ['png', 'jpg', 'jpeg', 'webp'];
+            const extensao = foto.name.split('.').pop().toLowerCase();
+
+            if (
+                !formatosPermitidos.includes(foto.type) ||
+                !extensoesPermitidas.includes(extensao)
+            ) {
+                mostrarMensagem("Formato de imagem inválido. Use PNG, JPG, JPEG ou WEBP.", "aviso");
+                return;
+            }
+
+            if (foto.size > tamanhoMaximoImagem) {
+                mostrarMensagem("Imagem muito pesada. Envie uma imagem com no máximo 5 MB.", "aviso");
+                return;
+            }
+
+            const formData = new FormData();
+
+            formData.append('usuario_id', usuario.id);
+            formData.append('foto', foto);
+            formData.append('legenda', legenda);
+
+            try {
+                if (botao) {
+                    botao.disabled = true;
+                    botao.innerText = "Adicionando...";
+                }
+
+                const res = await fetch(`${API_URL}/carros/${carroId}/fotos`, {
+                    method: 'POST',
+                    body: formData
+                });
+
+                const resposta = await res.json();
+
+                if (res.ok) {
+                    mostrarMensagem(resposta.mensagem || "Foto adicionada à galeria!", "sucesso");
+
+                    event.target.reset();
+
+                    const nomeArquivo = document.getElementById('galeria-foto-nome');
+
+                    if (nomeArquivo) {
+                        nomeArquivo.textContent = "Nenhum arquivo";
+                    }
+
+                    carregarGaleriaProjeto(carroId, true);
+                    return;
+                }
+
+                mostrarMensagem("Erro: " + (resposta.erro || "Não foi possível adicionar a foto."), "erro");
+
+            } catch (error) {
+                mostrarMensagem("Erro de conexão com o servidor.", "erro");
+                console.error(error);
+
+            } finally {
+                if (botao) {
+                    botao.disabled = false;
+                    botao.innerText = "Adicionar à galeria";
+                }
+            }
         }
 
         async function carregarEvolucoes(carroId, listaId = 'lista-evolucoes') {
@@ -3077,6 +3271,18 @@
 
             if (e.target.id === 'input-foto') {
                 const nome = document.getElementById('carro-foto-nome');
+
+                if (!nome) {
+                    return;
+                }
+
+                nome.textContent = e.target.files.length > 0
+                    ? e.target.files[0].name
+                    : "Nenhum arquivo";
+            }
+
+            if (e.target.id === 'galeria-foto-input') {
+                const nome = document.getElementById('galeria-foto-nome');
 
                 if (!nome) {
                     return;

--- a/style.css
+++ b/style.css
@@ -3110,7 +3110,7 @@
                 top: 12px;
                 z-index: 5;
                 display: grid;
-                grid-template-columns: repeat(3, minmax(0, 1fr));
+                grid-template-columns: repeat(4, minmax(0, 1fr));
                 gap: 6px;
                 padding: 6px;
                 border: 1px solid rgba(255, 255, 255, 0.085);
@@ -3195,6 +3195,125 @@
                 color: var(--text-muted);
                 font-size: 0.94rem;
                 line-height: 1.6;
+                text-transform: none;
+            }
+
+            .galeria-projeto-header {
+                display: flex;
+                align-items: flex-start;
+                justify-content: space-between;
+                gap: 12px;
+                margin-bottom: 16px;
+            }
+
+            .galeria-projeto-header h3 {
+                margin: 0 0 4px;
+                color: var(--text-main);
+                font-size: 1rem;
+                font-weight: 950;
+                letter-spacing: -0.02em;
+                text-align: left;
+                text-transform: none;
+            }
+
+            .galeria-projeto-header span {
+                display: block;
+                color: var(--text-muted);
+                font-size: 0.78rem;
+                line-height: 1.35;
+                text-transform: none;
+            }
+
+            .galeria-projeto-form {
+                display: grid;
+                gap: 10px;
+                margin-bottom: 16px;
+                padding: 12px;
+                border: 1px solid rgba(255, 71, 87, 0.16);
+                border-radius: var(--radius-md);
+                background: rgba(255, 71, 87, 0.055);
+            }
+
+            .galeria-projeto-form input {
+                margin-bottom: 0;
+                border-radius: var(--radius-md);
+                background: rgba(0, 0, 0, 0.24);
+                border-color: rgba(255, 255, 255, 0.1);
+                font-size: 0.82rem;
+            }
+
+            .btn-galeria-projeto {
+                min-height: 42px;
+                margin: 0;
+                border-radius: var(--radius-pill);
+            }
+
+            .galeria-projeto-lista {
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+                gap: 12px;
+            }
+
+            .galeria-projeto-card {
+                overflow: hidden;
+                border: 1px solid rgba(255, 255, 255, 0.075);
+                border-radius: var(--radius-md);
+                background: rgba(255, 255, 255, 0.035);
+            }
+
+            .galeria-projeto-card img,
+            .galeria-projeto-sem-foto {
+                display: block;
+                width: 100%;
+                aspect-ratio: 4 / 3;
+            }
+
+            .galeria-projeto-card img {
+                object-fit: cover;
+            }
+
+            .galeria-projeto-sem-foto {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                color: rgba(255, 255, 255, 0.28);
+                background:
+                    radial-gradient(circle at center, rgba(255, 71, 87, 0.12), transparent 38%),
+                    rgba(0, 0, 0, 0.3);
+                font-size: 0.7rem;
+                font-weight: 950;
+                letter-spacing: 0.1em;
+                text-transform: uppercase;
+            }
+
+            .galeria-projeto-info {
+                display: grid;
+                gap: 4px;
+                padding: 11px 12px 12px;
+            }
+
+            .galeria-projeto-info strong {
+                color: var(--text-main);
+                font-size: 0.84rem;
+                font-weight: 950;
+                line-height: 1.25;
+                text-transform: none;
+            }
+
+            .galeria-projeto-info span {
+                color: var(--text-soft);
+                font-size: 0.66rem;
+                font-weight: 850;
+                text-transform: uppercase;
+            }
+
+            .galeria-projeto-vazio {
+                padding: 13px;
+                border: 1px dashed rgba(255, 255, 255, 0.11);
+                border-radius: var(--radius-md);
+                color: var(--text-muted);
+                font-size: 0.82rem;
+                text-align: center;
                 text-transform: none;
             }
 
@@ -4115,6 +4234,10 @@
             .upload-container:hover {
                 border-color: #ff4757;
                 background: #111;
+            }
+
+            .upload-container input[type="file"] {
+                display: none;
             }
 
             .upload-btn {
@@ -5237,15 +5360,18 @@
 
                 .pagina-projeto-tabs {
                     top: 8px;
+                    display: flex;
                     gap: 4px;
                     padding: 5px;
+                    overflow-x: auto;
                     border-radius: 20px;
                     box-shadow: 0 14px 34px rgba(0, 0, 0, 0.38);
                 }
 
                 .pagina-projeto-tab {
+                    flex: 1 0 max-content;
                     min-height: 38px;
-                    padding: 8px 4px;
+                    padding: 8px 10px;
                     font-size: 0.58rem;
                     letter-spacing: 0.035em;
                 }
@@ -5353,5 +5479,31 @@
                 .pagina-projeto .evolucao-conteudo {
                     padding: 10px;
                     border-radius: 14px;
+                }
+
+                .pagina-projeto .galeria-projeto-header {
+                    margin-bottom: 12px;
+                }
+
+                .pagina-projeto .galeria-projeto-header span {
+                    font-size: 0.74rem;
+                }
+
+                .pagina-projeto .galeria-projeto-form {
+                    padding: 10px;
+                    border-radius: 16px;
+                }
+
+                .pagina-projeto .galeria-projeto-lista {
+                    grid-template-columns: 1fr;
+                    gap: 10px;
+                }
+
+                .pagina-projeto .galeria-projeto-card {
+                    border-radius: 16px;
+                }
+
+                .pagina-projeto .galeria-projeto-info {
+                    padding: 10px;
                 }
             }


### PR DESCRIPTION
Closes #168

## Resumo

Adiciona a estrutura inicial de galeria de fotos para projetos automotivos.

## Alterações

- Cria a tabela `fotos_projeto` para armazenar imagens extras dos projetos
- Adiciona rotas para listar e cadastrar fotos da galeria
- Permite que o dono do projeto adicione fotos extras pela tela dedicada
- Exibe a aba Galeria na tela dedicada do projeto
- Mantém a imagem principal atual como capa do projeto
- Adiciona visual inicial da galeria com foco em mobile-first
- Atualiza o arquivo `garagem_digital.sql`

## Observação

Essa PR altera a estrutura do banco.