### PR TITLE
feat: permite remover fotos da galeria do projeto

### DIFF
--- a/app.py
+++ b/app.py
@@ -904,6 +904,71 @@ def cadastrar_foto_projeto(id):
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
 
+@app.route('/carros/<int:id>/fotos/<int:foto_id>', methods=['DELETE'])
+def remover_foto_projeto(id, foto_id):
+    usuario_id = str(request.args.get('usuario_id', '')).strip()
+
+    if not usuario_id:
+        return jsonify({"erro": "Usuário não informado."}), 400
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        if not usuario_existe(cursor, usuario_id):
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Usuário inválido."}), 403
+
+        cursor.execute(
+            """
+            SELECT
+                fp.id,
+                fp.imagem_url,
+                c.usuario_id AS dono_id
+            FROM fotos_projeto fp
+            INNER JOIN carros c ON c.id = fp.carro_id
+            WHERE fp.id = %s AND fp.carro_id = %s
+            """,
+            (foto_id, id)
+        )
+
+        foto = cursor.fetchone()
+
+        if not foto:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Foto não encontrada."}), 404
+
+        if str(foto['dono_id']) != usuario_id:
+            cursor.close()
+            conexao.close()
+            return jsonify({"erro": "Você não tem permissão para remover esta foto."}), 403
+
+        cursor.execute(
+            "DELETE FROM fotos_projeto WHERE id = %s AND carro_id = %s",
+            (foto_id, id)
+        )
+
+        conexao.commit()
+
+        imagem_url = foto.get('imagem_url')
+
+        cursor.close()
+        conexao.close()
+
+        if imagem_url:
+            pasta_uploads = os.path.abspath(app.config['UPLOAD_FOLDER'])
+            caminho_arquivo = os.path.abspath(os.path.join(pasta_uploads, imagem_url))
+
+            if caminho_arquivo.startswith(pasta_uploads + os.sep) and os.path.exists(caminho_arquivo):
+                os.remove(caminho_arquivo)
+
+        return jsonify({"mensagem": "Foto removida da galeria."}), 200
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
 @app.route('/usuarios/<int:id>', methods=['GET'])
 def buscar_usuario(id):
     usuario_logado_id = request.args.get('usuario_logado_id')

--- a/script.js
+++ b/script.js
@@ -1224,6 +1224,16 @@
                             <div class="galeria-projeto-info">
                                 <strong>${legenda ? textoFeedbackSeguro(legenda) : 'Registro do projeto'}</strong>
                                 <span>${formatarTempoRelativo(foto.criado_em)}</span>
+
+                                ${dono ? `
+                                    <button
+                                        type="button"
+                                        class="btn-remover-foto-galeria"
+                                        onclick="removerFotoGaleria(${carroId}, ${foto.id})"
+                                    >
+                                        Remover foto
+                                    </button>
+                                ` : ''}
                             </div>
                         </article>
                     `;
@@ -1324,6 +1334,41 @@
                     botao.disabled = false;
                     botao.innerText = "Adicionar à galeria";
                 }
+            }
+        }
+
+        async function removerFotoGaleria(carroId, fotoId) {
+            const usuario = getUsuarioLogado();
+
+            if (!usuario) {
+                mostrarMensagem("Faça login para remover fotos da galeria.", "aviso");
+                return;
+            }
+
+            const confirmar = confirm("Remover esta foto da galeria?");
+
+            if (!confirmar) {
+                return;
+            }
+
+            try {
+                const res = await fetch(`${API_URL}/carros/${carroId}/fotos/${fotoId}?usuario_id=${usuario.id}`, {
+                    method: 'DELETE'
+                });
+
+                const resposta = await res.json();
+
+                if (res.ok) {
+                    mostrarMensagem(resposta.mensagem || "Foto removida da galeria.", "sucesso");
+                    carregarGaleriaProjeto(carroId, true);
+                    return;
+                }
+
+                mostrarMensagem("Erro: " + (resposta.erro || "Não foi possível remover a foto."), "erro");
+
+            } catch (error) {
+                mostrarMensagem("Erro de conexão com o servidor.", "erro");
+                console.error(error);
             }
         }
 

--- a/style.css
+++ b/style.css
@@ -3307,6 +3307,28 @@
                 text-transform: uppercase;
             }
 
+            .btn-remover-foto-galeria {
+                width: fit-content;
+                min-height: auto;
+                margin: 6px 0 0;
+                padding: 7px 10px;
+                border: 1px solid rgba(255, 71, 87, 0.28);
+                border-radius: var(--radius-pill);
+                background: rgba(255, 71, 87, 0.08);
+                color: #ff7a84;
+                font-size: 0.62rem;
+                font-weight: 950;
+                letter-spacing: 0.075em;
+                text-transform: uppercase;
+                box-shadow: none;
+            }
+
+            .btn-remover-foto-galeria:hover {
+                transform: none;
+                border-color: rgba(255, 71, 87, 0.48);
+                background: rgba(255, 71, 87, 0.14);
+            }
+
             .galeria-projeto-vazio {
                 padding: 13px;
                 border: 1px dashed rgba(255, 255, 255, 0.11);


### PR DESCRIPTION
Closes #170

## Resumo

Permite que o dono do projeto remova fotos adicionadas à galeria.

## Alterações

- Adiciona rota para remover fotos da galeria
- Garante que apenas o dono do projeto possa remover fotos
- Exibe botão de remover apenas para o dono
- Atualiza a galeria após a remoção da foto
- Remove o arquivo físico da imagem quando possível
- Adiciona estilo discreto para o botão de remoção

## Observação

Não houve alteração estrutural no banco.

O arquivo `garagem_digital.sql` não precisou ser alterado.