### PR TITLE
fix: fecha tela de projeto ao sair da conta

### DIFF
--- a/script.js
+++ b/script.js
@@ -478,6 +478,8 @@
         }
 
         function sair() {
+            fecharTelaProjeto();
+
             localStorage.removeItem('usuarioLogado');
             resetarFormulario();
             atualizarTelaUsuario();


### PR DESCRIPTION
Closes #172

## Resumo

Corrige o bug em que a tela dedicada de projeto continuava aberta após sair da conta.

## Alterações

- Fecha a tela dedicada de projeto antes de concluir o logout
- Remove o estado visual de tela de projeto aberta
- Evita sobreposição entre a tela de login e a página do projeto
- Mantém o fluxo normal de logout e atualização da interface

## Observação

Não houve alteração estrutural no banco.

O arquivo `garagem_digital.sql` não precisou ser alterado.