### PR TITLE
feat: permite adicionar imagem ao diário de evolução

### DIFF
--- a/app.py
+++ b/app.py
@@ -687,6 +687,7 @@ def listar_evolucoes_projeto(id):
                 e.usuario_id,
                 e.titulo,
                 e.descricao,
+                e.imagem_url,
                 e.criado_em,
                 u.nome AS nome_usuario,
                 u.username AS username_usuario
@@ -712,7 +713,12 @@ def listar_evolucoes_projeto(id):
 
 @app.route('/carros/<int:id>/evolucoes', methods=['POST'])
 def cadastrar_evolucao_projeto(id):
-    dados = request.get_json(silent=True) or {}
+    if request.content_type and request.content_type.startswith('multipart/form-data'):
+        dados = request.form
+        imagem = request.files.get('imagem')
+    else:
+        dados = request.get_json(silent=True) or {}
+        imagem = None
 
     usuario_id = str(dados.get('usuario_id', '')).strip()
     titulo = str(dados.get('titulo', '')).strip()
@@ -760,12 +766,17 @@ def cadastrar_evolucao_projeto(id):
             conexao.close()
             return jsonify({"erro": "Você não tem permissão para atualizar este projeto."}), 403
 
+        imagem_url = None
+
+        if imagem and imagem.filename != "":
+            imagem_url = salvar_imagem(imagem)
+
         cursor.execute(
             """
-            INSERT INTO evolucoes_projeto (carro_id, usuario_id, titulo, descricao)
-            VALUES (%s, %s, %s, %s)
+            INSERT INTO evolucoes_projeto (carro_id, usuario_id, titulo, descricao, imagem_url)
+            VALUES (%s, %s, %s, %s, %s)
             """,
-            (id, usuario_id, titulo, descricao)
+            (id, usuario_id, titulo, descricao, imagem_url)
         )
 
         conexao.commit()

--- a/garagem_digital.sql
+++ b/garagem_digital.sql
@@ -110,6 +110,7 @@ CREATE TABLE evolucoes_projeto (
     usuario_id INT NOT NULL,
     titulo VARCHAR(120) NOT NULL,
     descricao TEXT NOT NULL,
+    imagem_url VARCHAR(255),
     criado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     KEY idx_evolucoes_carro (carro_id),

--- a/script.js
+++ b/script.js
@@ -963,6 +963,17 @@
                                     placeholder="Conte o que mudou no projeto..."
                                 ></textarea>
 
+                                <label class="upload-container evolucao-upload-container">
+                                    <span class="upload-btn">Escolher imagem</span>
+                                    <span class="upload-nome" id="evolucao-imagem-nome">Nenhum arquivo</span>
+
+                                    <input
+                                        type="file"
+                                        id="input-evolucao-imagem"
+                                        accept="image/png, image/jpeg, image/webp"
+                                    >
+                                </label>
+
                                 <button type="submit" class="btn-evolucao">
                                     Registrar evolução
                                 </button>
@@ -1131,6 +1142,37 @@
                                         <span>Últimas atualizações, mudanças e fases do projeto</span>
                                     </div>
                                 </div>
+
+                                ${dono ? `
+                                    <form class="evolucao-form" onsubmit="enviarEvolucao(event, ${carro.id}, 'lista-evolucoes-tela')">
+                                        <input
+                                            type="text"
+                                            id="input-evolucao-titulo"
+                                            placeholder="Título da atualização"
+                                            maxlength="120"
+                                        >
+
+                                        <textarea
+                                            id="input-evolucao-descricao"
+                                            placeholder="Conte o que mudou no projeto..."
+                                        ></textarea>
+
+                                        <label class="upload-container evolucao-upload-container">
+                                            <span class="upload-btn">Escolher imagem</span>
+                                            <span class="upload-nome" id="evolucao-imagem-nome">Nenhum arquivo</span>
+
+                                            <input
+                                                type="file"
+                                                id="input-evolucao-imagem"
+                                                accept="image/png, image/jpeg, image/webp"
+                                            >
+                                        </label>
+
+                                        <button type="submit" class="btn-evolucao">
+                                            Registrar evolução
+                                        </button>
+                                    </form>
+                                ` : ''}
 
                                 <div id="lista-evolucoes-tela" class="evolucao-lista">
                                     <div class="evolucao-vazio">Carregando evolução do projeto...</div>
@@ -1397,6 +1439,7 @@
 
                 lista.innerHTML = evolucoes.map(evolucao => {
                     const descricao = textoFeedbackSeguro(evolucao.descricao).replace(/\n/g, '<br>');
+                    const imagem = evolucao.imagem_url ? `${API_URL}/uploads/${evolucao.imagem_url}` : '';
 
                     return `
                         <article class="evolucao-item">
@@ -1407,6 +1450,14 @@
                                     <strong>${textoFeedbackSeguro(evolucao.titulo)}</strong>
                                     <span>${formatarTempoRelativo(evolucao.criado_em)}</span>
                                 </div>
+
+                                ${imagem ? `
+                                    <img
+                                        src="${imagem}"
+                                        alt="Imagem da evolução do projeto"
+                                        class="evolucao-imagem"
+                                    >
+                                ` : ''}
 
                                 <p>${descricao}</p>
                             </div>
@@ -1420,7 +1471,7 @@
             }
         }
 
-        async function enviarEvolucao(event, carroId) {
+        async function enviarEvolucao(event, carroId, listaId = 'lista-evolucoes') {
             event.preventDefault();
 
             const usuario = getUsuarioLogado();
@@ -1432,9 +1483,13 @@
 
             const inputTitulo = document.getElementById('input-evolucao-titulo');
             const inputDescricao = document.getElementById('input-evolucao-descricao');
+            const inputImagem = document.getElementById('input-evolucao-imagem');
 
             const titulo = inputTitulo.value.trim();
             const descricao = inputDescricao.value.trim();
+            const imagem = inputImagem && inputImagem.files.length > 0
+                ? inputImagem.files[0]
+                : null;
 
             if (!titulo) {
                 mostrarMensagem("Digite um título para a evolução.", "aviso");
@@ -1446,17 +1501,40 @@
                 return;
             }
 
+            if (imagem) {
+                const tamanhoMaximoImagem = 5 * 1024 * 1024;
+                const formatosPermitidos = ['image/png', 'image/jpeg', 'image/webp'];
+                const extensoesPermitidas = ['png', 'jpg', 'jpeg', 'webp'];
+                const extensao = imagem.name.split('.').pop().toLowerCase();
+
+                if (
+                    !formatosPermitidos.includes(imagem.type) ||
+                    !extensoesPermitidas.includes(extensao)
+                ) {
+                    mostrarMensagem("Formato de imagem inválido. Use PNG, JPG, JPEG ou WEBP.", "aviso");
+                    return;
+                }
+
+                if (imagem.size > tamanhoMaximoImagem) {
+                    mostrarMensagem("Imagem muito pesada. Envie uma imagem com no máximo 5 MB.", "aviso");
+                    return;
+                }
+            }
+
+            const formData = new FormData();
+
+            formData.append('usuario_id', usuario.id);
+            formData.append('titulo', titulo);
+            formData.append('descricao', descricao);
+
+            if (imagem) {
+                formData.append('imagem', imagem);
+            }
+
             try {
                 const res = await fetch(`${API_URL}/carros/${carroId}/evolucoes`, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({
-                        usuario_id: usuario.id,
-                        titulo,
-                        descricao
-                    })
+                    body: formData
                 });
 
                 const resposta = await res.json();
@@ -1467,7 +1545,17 @@
                     inputTitulo.value = '';
                     inputDescricao.value = '';
 
-                    carregarEvolucoes(carroId);
+                    if (inputImagem) {
+                        inputImagem.value = '';
+                    }
+
+                    const nomeImagem = document.getElementById('evolucao-imagem-nome');
+
+                    if (nomeImagem) {
+                        nomeImagem.textContent = 'Nenhum arquivo';
+                    }
+
+                    carregarEvolucoes(carroId, listaId);
                     return;
                 }
 
@@ -3330,6 +3418,18 @@
 
             if (e.target.id === 'galeria-foto-input') {
                 const nome = document.getElementById('galeria-foto-nome');
+
+                if (!nome) {
+                    return;
+                }
+
+                nome.textContent = e.target.files.length > 0
+                    ? e.target.files[0].name
+                    : "Nenhum arquivo";
+            }
+
+            if (e.target.id === 'input-evolucao-imagem') {
+                const nome = document.getElementById('evolucao-imagem-nome');
 
                 if (!nome) {
                     return;

--- a/style.css
+++ b/style.css
@@ -3392,6 +3392,12 @@
                 background: rgba(0, 0, 0, 0.24);
                 border-color: rgba(255, 255, 255, 0.1);
                 font-size: 0.82rem;
+                text-transform: none;
+            }
+
+            .evolucao-form input::placeholder,
+            .evolucao-form textarea::placeholder {
+                text-transform: none;
             }
 
             .evolucao-form textarea {
@@ -3457,6 +3463,16 @@
                 font-weight: 850;
                 white-space: nowrap;
                 text-transform: uppercase;
+            }
+
+            .evolucao-imagem {
+                display: block;
+                width: min(100%, 620px);
+                max-height: 260px;
+                margin-bottom: 10px;
+                border-radius: 14px;
+                object-fit: cover;
+                border: 1px solid rgba(255, 255, 255, 0.075);
             }
 
             .evolucao-conteudo p {
@@ -5527,5 +5543,10 @@
 
                 .pagina-projeto .galeria-projeto-info {
                     padding: 10px;
+                }
+
+                .pagina-projeto .evolucao-imagem {
+                    width: 100%;
+                    max-height: 230px;
                 }
             }


### PR DESCRIPTION
Closes #174

## Resumo

Permite adicionar uma imagem opcional ao registrar uma evolução do projeto.

## Alterações

- Adiciona o campo `imagem_url` na tabela `evolucoes_projeto`
- Atualiza o arquivo `garagem_digital.sql`
- Permite envio de imagem opcional no registro de evolução
- Mantém título e descrição como campos obrigatórios
- Exibe imagem no card da evolução quando existir
- Mantém evoluções sem imagem funcionando normalmente
- Adiciona upload de imagem no formulário do diário da tela dedicada
- Atualiza a lista correta de evoluções após registrar pela tela de projeto

## Observação

Essa PR altera a estrutura do banco.

O arquivo `garagem_digital.sql` foi atualizado.