### PR TITLE
feat: separa diário em seção principal

### DIFF
--- a/app.py
+++ b/app.py
@@ -930,6 +930,87 @@ def remover_evolucao_projeto(id, evolucao_id):
     except Exception as e:
         return jsonify({"erro": str(e)}), 500
 
+@app.route('/evolucoes/feed', methods=['GET'])
+def listar_feed_evolucoes():
+    usuario_id = request.args.get('usuario_id', '')
+
+    try:
+        conexao = mysql.connector.connect(**db_config)
+        cursor = conexao.cursor(dictionary=True)
+
+        cursor.execute(
+            """
+            SELECT
+                e.id,
+                e.carro_id,
+                e.usuario_id,
+                e.titulo,
+                e.descricao,
+                e.imagem_url,
+                e.criado_em,
+
+                u.nome AS nome_usuario,
+                u.username AS username_usuario,
+                u.avatar_url AS avatar_usuario,
+
+                c.usuario_id AS carro_usuario_id,
+                c.nome_dono,
+                c.modelo,
+                c.ano,
+                c.cor,
+                c.placa,
+                c.tipo_suspensao,
+                c.aro_roda,
+                c.foto_url,
+                c.historia,
+                c.motor,
+                c.cambio,
+                c.combustivel,
+                c.potencia_estimada,
+                c.preparacao,
+                c.status_projeto,
+
+                (
+                    SELECT COUNT(*)
+                    FROM curtidas cur
+                    WHERE cur.carro_id = c.id
+                ) AS total_curtidas,
+
+                (
+                    SELECT COUNT(*)
+                    FROM comentarios com
+                    WHERE com.carro_id = c.id
+                ) AS total_comentarios,
+
+                CASE
+                    WHEN EXISTS (
+                        SELECT 1
+                        FROM curtidas cur_usuario
+                        WHERE cur_usuario.carro_id = c.id
+                        AND cur_usuario.usuario_id = %s
+                    )
+                    THEN 1
+                    ELSE 0
+                END AS curtido_pelo_usuario
+            FROM evolucoes_projeto e
+            INNER JOIN carros c ON c.id = e.carro_id
+            INNER JOIN usuarios u ON u.id = e.usuario_id
+            ORDER BY e.criado_em DESC, e.id DESC
+            LIMIT 8
+            """,
+            (usuario_id if usuario_id else 0,)
+        )
+
+        evolucoes = cursor.fetchall()
+
+        cursor.close()
+        conexao.close()
+
+        return jsonify(evolucoes)
+
+    except Exception as e:
+        return jsonify({"erro": str(e)}), 500
+
 @app.route('/carros/<int:id>/fotos', methods=['GET'])
 def listar_fotos_projeto(id):
     try:

--- a/index.html
+++ b/index.html
@@ -248,34 +248,71 @@
             </form>
         </div>
 
-        <div class="abas-garagem">
-            <button type="button" id="aba-todos" class="ativo" onclick="mostrarTodosProjetos()">
-                Todos os projetos
+        <div class="app-nav">
+            <button type="button" id="nav-garagem" class="ativo" onclick="mostrarSecaoPrincipal('garagem')">
+                Garagem
             </button>
 
-            <button type="button" id="aba-meus" onclick="mostrarMeusProjetos()">
-                Meus projetos
+            <button type="button" id="nav-diario" onclick="mostrarSecaoPrincipal('diario')">
+                Diário
             </button>
-        </div>
 
-        <div class="filtros-container">
-            <input type="text" id="filtro-modelo" placeholder="Modelo">
-
-            <select id="filtro-suspensao">
-                <option value="">TODAS AS SUSPENSÕES</option>
-                <option value="Fixa">Fixa</option>
-                <option value="Ar">Ar</option>
-                <option value="Rosca">Rosca</option>
-            </select>
-
-            <input type="number" id="filtro-aro" placeholder="Aro" style="width: 70px;">
-
-            <button type="button" class="btn-buscar" onclick="carregarGaragem()">
-                Buscar
+            <button type="button" id="nav-encontros" onclick="mostrarSecaoPrincipal('encontros')">
+                Encontros
             </button>
         </div>
 
-        <div class="galeria" id="lista-carros"></div>
+        <section class="secao-principal secao-principal-ativa" id="secao-garagem">
+            <div class="abas-garagem">
+                <button type="button" id="aba-todos" class="ativo" onclick="mostrarTodosProjetos()">
+                    Todos os projetos
+                </button>
+
+                <button type="button" id="aba-meus" onclick="mostrarMeusProjetos()">
+                    Meus projetos
+                </button>
+            </div>
+
+            <div class="filtros-container">
+                <input type="text" id="filtro-modelo" placeholder="Modelo">
+
+                <select id="filtro-suspensao">
+                    <option value="">TODAS AS SUSPENSÕES</option>
+                    <option value="Fixa">Fixa</option>
+                    <option value="Ar">Ar</option>
+                    <option value="Rosca">Rosca</option>
+                </select>
+
+                <input type="number" id="filtro-aro" placeholder="Aro" style="width: 70px;">
+
+                <button type="button" class="btn-buscar" onclick="carregarGaragem()">
+                    Buscar
+                </button>
+            </div>
+
+            <div class="galeria" id="lista-carros"></div>
+        </section>
+
+        <section class="secao-principal feed-evolucoes" id="feed-evolucoes">
+            <div class="feed-evolucoes-header">
+                <div>
+                    <span>Atualizações recentes</span>
+                    <h2>Diário da Garagem</h2>
+                </div>
+
+                <p>Novas fases, peças, ajustes e registros dos projetos da comunidade.</p>
+            </div>
+
+            <div class="feed-evolucoes-lista" id="lista-feed-evolucoes"></div>
+        </section>
+
+        <section class="secao-principal secao-encontros" id="secao-encontros">
+            <div class="secao-encontros-card">
+                <span>Em breve</span>
+                <h2>Central de encontros</h2>
+                <p>Um espaço futuro para rolês, eventos, clubes e encontros automotivos.</p>
+            </div>
+        </section>
     </div>
 
     <!-- Tela dedicada de projeto -->

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 // Configuração global e estado da aplicação
         const API_URL = 'http://127.0.0.1:5000';
         let todosCarros = [];
+        let feedEvolucoesCache = {};
         let modoGaragem = "todos";
         let equipeParaReabrirAposProjeto = null;
         let perfilParaReabrirAposProjeto = null;
@@ -514,6 +515,181 @@
             if (botao) {
                 botao.innerText = '+ Estacionar novo projeto';
             }
+        }
+
+        function mostrarSecaoPrincipal(secao) {
+            const secoes = {
+                garagem: document.getElementById('secao-garagem'),
+                diario: document.getElementById('feed-evolucoes'),
+                encontros: document.getElementById('secao-encontros')
+            };
+
+            const botoes = {
+                garagem: document.getElementById('nav-garagem'),
+                diario: document.getElementById('nav-diario'),
+                encontros: document.getElementById('nav-encontros')
+            };
+
+            Object.values(secoes).forEach(secaoEl => {
+                if (secaoEl) {
+                    secaoEl.classList.remove('secao-principal-ativa');
+                }
+            });
+
+            Object.values(botoes).forEach(botao => {
+                if (botao) {
+                    botao.classList.remove('ativo');
+                }
+            });
+
+            if (secoes[secao]) {
+                secoes[secao].classList.add('secao-principal-ativa');
+            }
+
+            if (botoes[secao]) {
+                botoes[secao].classList.add('ativo');
+            }
+
+            if (secao === 'diario') {
+                carregarFeedEvolucoes();
+            }
+        }
+
+        async function carregarFeedEvolucoes() {
+            const container = document.getElementById('feed-evolucoes');
+            const lista = document.getElementById('lista-feed-evolucoes');
+
+            if (!container || !lista) {
+                return;
+            }
+
+            if (modoGaragem !== "todos") {
+                container.style.display = 'none';
+                lista.innerHTML = '';
+                return;
+            }
+
+            container.style.display = 'block';
+            lista.innerHTML = '<div class="feed-evolucoes-vazio">Carregando atualizações...</div>';
+
+            const params = new URLSearchParams();
+            const usuario = getUsuarioLogado();
+
+            if (usuario) {
+                params.append('usuario_id', usuario.id);
+            }
+
+            try {
+                const res = await fetch(`${API_URL}/evolucoes/feed?${params.toString()}`);
+                const evolucoes = await res.json();
+
+                if (!Array.isArray(evolucoes) || evolucoes.length === 0) {
+                    container.style.display = 'none';
+                    lista.innerHTML = '';
+                    return;
+                }
+
+                feedEvolucoesCache = {};
+
+                lista.innerHTML = evolucoes.map(evolucao => {
+                    feedEvolucoesCache[evolucao.id] = evolucao;
+
+                    const descricaoOriginal = String(evolucao.descricao || '').trim();
+                    const descricaoCurta = descricaoOriginal.length > 150
+                        ? `${descricaoOriginal.slice(0, 150).trim()}...`
+                        : descricaoOriginal;
+
+                    const imagem = evolucao.imagem_url
+                        ? `${API_URL}/uploads/${evolucao.imagem_url}`
+                        : (evolucao.foto_url ? `${API_URL}/uploads/${evolucao.foto_url}` : '');
+
+                    const avatar = evolucao.avatar_usuario
+                        ? (evolucao.avatar_usuario.startsWith('http')
+                            ? evolucao.avatar_usuario
+                            : `${API_URL}/uploads/${evolucao.avatar_usuario}`)
+                        : '';
+
+                    const nomeAutor = evolucao.username_usuario
+                        ? `@${evolucao.username_usuario}`
+                        : (evolucao.nome_usuario || 'Usuário');
+
+                    const inicial = String(evolucao.nome_usuario || evolucao.username_usuario || 'G')
+                        .charAt(0)
+                        .toUpperCase();
+
+                    return `
+                        <article class="feed-evolucao-card" onclick="abrirProjetoPeloFeed(${evolucao.id})">
+                            <div class="feed-evolucao-topo">
+                                ${avatar
+                                    ? `<img src="${avatar}" class="feed-evolucao-avatar" alt="">`
+                                    : `<div class="feed-evolucao-avatar-fallback">${textoFeedbackSeguro(inicial)}</div>`
+                                }
+
+                                <div>
+                                    <strong>${textoFeedbackSeguro(nomeAutor)}</strong>
+                                    <span>atualizou ${textoFeedbackSeguro(evolucao.modelo)} (${textoFeedbackSeguro(evolucao.ano)})</span>
+                                </div>
+
+                                <time>${formatarTempoRelativo(evolucao.criado_em)}</time>
+                            </div>
+
+                            ${imagem
+                                ? `<img src="${imagem}" class="feed-evolucao-img" alt="Imagem da evolução">`
+                                : `<div class="feed-evolucao-sem-img">Sem imagem</div>`
+                            }
+
+                            <div class="feed-evolucao-corpo">
+                                <span class="feed-evolucao-tag">Diário de evolução</span>
+                                <h3>${textoFeedbackSeguro(evolucao.titulo)}</h3>
+                                <p>${textoFeedbackSeguro(descricaoCurta)}</p>
+
+                                <button type="button" class="feed-evolucao-abrir">
+                                    Abrir projeto
+                                </button>
+                            </div>
+                        </article>
+                    `;
+                }).join('');
+
+            } catch (error) {
+                console.error(error);
+                container.style.display = 'none';
+            }
+        }
+
+
+        function abrirProjetoPeloFeed(evolucaoId) {
+            const evolucao = feedEvolucoesCache[evolucaoId];
+
+            if (!evolucao) {
+                mostrarMensagem("Não foi possível abrir este projeto.", "erro");
+                return;
+            }
+
+            const carro = {
+                id: evolucao.carro_id,
+                usuario_id: evolucao.carro_usuario_id,
+                nome_dono: evolucao.nome_dono,
+                modelo: evolucao.modelo,
+                ano: evolucao.ano,
+                cor: evolucao.cor,
+                placa: evolucao.placa,
+                tipo_suspensao: evolucao.tipo_suspensao,
+                aro_roda: evolucao.aro_roda,
+                foto_url: evolucao.foto_url,
+                historia: evolucao.historia,
+                motor: evolucao.motor,
+                cambio: evolucao.cambio,
+                combustivel: evolucao.combustivel,
+                potencia_estimada: evolucao.potencia_estimada,
+                preparacao: evolucao.preparacao,
+                status_projeto: evolucao.status_projeto,
+                total_curtidas: evolucao.total_curtidas || 0,
+                total_comentarios: evolucao.total_comentarios || 0,
+                curtido_pelo_usuario: evolucao.curtido_pelo_usuario
+            };
+
+            abrirTelaProjeto(carro);
         }
 
         async function carregarGaragem() {

--- a/script.js
+++ b/script.js
@@ -563,13 +563,6 @@
                 return;
             }
 
-            if (modoGaragem !== "todos") {
-                container.style.display = 'none';
-                lista.innerHTML = '';
-                return;
-            }
-
-            container.style.display = 'block';
             lista.innerHTML = '<div class="feed-evolucoes-vazio">Carregando atualizações...</div>';
 
             const params = new URLSearchParams();
@@ -584,8 +577,7 @@
                 const evolucoes = await res.json();
 
                 if (!Array.isArray(evolucoes) || evolucoes.length === 0) {
-                    container.style.display = 'none';
-                    lista.innerHTML = '';
+                    lista.innerHTML = '<div class="feed-evolucoes-vazio">Nenhuma atualização recente ainda.</div>';
                     return;
                 }
 
@@ -653,7 +645,7 @@
 
             } catch (error) {
                 console.error(error);
-                container.style.display = 'none';
+                lista.innerHTML = '<div class="feed-evolucoes-vazio">Erro ao carregar atualizações.</div>';
             }
         }
 

--- a/style.css
+++ b/style.css
@@ -631,6 +631,95 @@
             background-color: transparent;
         }
 
+        .app-nav {
+            width: min(860px, calc(100% - 32px));
+            margin: 0 auto 18px;
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 6px;
+            padding: 6px;
+            border: 1px solid rgba(255, 255, 255, 0.09);
+            border-radius: var(--radius-pill);
+            background:
+                linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent),
+                rgba(12, 12, 12, 0.9);
+            box-shadow: 0 18px 42px rgba(0, 0, 0, 0.34);
+        }
+
+        .app-nav button {
+            min-height: 44px;
+            margin: 0;
+            border-radius: var(--radius-pill);
+            border: 1px solid transparent;
+            background: transparent;
+            color: var(--text-muted);
+            font-size: 0.74rem;
+            font-weight: 950;
+            letter-spacing: 0.07em;
+            text-transform: uppercase;
+            box-shadow: none;
+        }
+
+        .app-nav button:hover {
+            background: rgba(255, 255, 255, 0.045);
+            border-color: rgba(255, 255, 255, 0.1);
+            color: var(--text-main);
+            transform: none;
+        }
+
+        .app-nav button.ativo {
+            background:
+                linear-gradient(135deg, rgba(255, 71, 87, 0.3), rgba(255, 71, 87, 0.12)),
+                rgba(255, 71, 87, 0.08);
+            border-color: rgba(255, 71, 87, 0.5);
+            color: #ff9aa2;
+            box-shadow: 0 12px 28px rgba(255, 71, 87, 0.16);
+        }
+
+        .secao-principal {
+            display: none;
+        }
+
+        .secao-principal.secao-principal-ativa {
+            display: block;
+        }
+
+        .secao-encontros {
+            width: min(860px, calc(100% - 32px));
+            margin: 0 auto 26px;
+        }
+
+        .secao-encontros-card {
+            padding: 28px;
+            border: 1px solid rgba(255, 255, 255, 0.09);
+            border-radius: var(--radius-xl);
+            background:
+                radial-gradient(circle at top left, rgba(255, 71, 87, 0.13), transparent 36%),
+                linear-gradient(145deg, rgba(255, 255, 255, 0.04), transparent),
+                rgba(16, 16, 16, 0.88);
+            box-shadow: 0 22px 48px rgba(0, 0, 0, 0.32);
+        }
+
+        .secao-encontros-card span {
+            display: inline-block;
+            margin-bottom: 8px;
+            color: #ff6f7b;
+            font-size: 0.68rem;
+            font-weight: 950;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+        }
+
+        .secao-encontros-card h2 {
+            margin: 0 0 8px;
+            color: var(--text-main);
+        }
+
+        .secao-encontros-card p {
+            margin: 0;
+            color: var(--text-muted);
+        }
+
         .abas-garagem {
             display: flex;
             gap: 10px;
@@ -734,6 +823,209 @@
         .btn-buscar:active {
             transform: translateY(0);
             box-shadow: 0 8px 18px rgba(255, 71, 87, 0.18);
+        }
+
+        .feed-evolucoes {
+            max-width: 1040px;
+            margin: 0 auto 26px;
+            padding: 18px;
+            border: 1px solid rgba(255, 255, 255, 0.085);
+            border-radius: var(--radius-xl);
+            background:
+                radial-gradient(circle at top left, rgba(255, 71, 87, 0.12), transparent 34%),
+                linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent),
+                rgba(12, 12, 12, 0.82);
+            box-shadow: var(--shadow-soft);
+        }
+
+        .feed-evolucoes-header {
+            display: flex;
+            align-items: flex-end;
+            justify-content: space-between;
+            gap: 18px;
+            margin-bottom: 16px;
+        }
+
+        .feed-evolucoes-header span {
+            display: block;
+            margin-bottom: 5px;
+            color: var(--accent);
+            font-size: 0.68rem;
+            font-weight: 950;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+        }
+
+        .feed-evolucoes-header h2 {
+            margin: 0;
+            color: var(--text-main);
+            font-size: 1.28rem;
+            font-weight: 950;
+        }
+
+        .feed-evolucoes-header p {
+            max-width: 360px;
+            margin: 0;
+            color: var(--text-muted);
+            font-size: 0.82rem;
+            line-height: 1.45;
+            text-align: right;
+        }
+
+        .feed-evolucoes-lista {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 14px;
+        }
+
+        .feed-evolucao-card {
+            overflow: hidden;
+            border: 1px solid rgba(255, 255, 255, 0.085);
+            border-radius: var(--radius-lg);
+            background:
+                linear-gradient(145deg, rgba(255, 255, 255, 0.04), transparent),
+                rgba(255, 255, 255, 0.032);
+            cursor: pointer;
+            transition:
+                transform var(--transition-base),
+                border-color var(--transition-base),
+                box-shadow var(--transition-base);
+        }
+
+        .feed-evolucao-card:hover {
+            transform: translateY(-3px);
+            border-color: rgba(255, 71, 87, 0.42);
+            box-shadow: 0 18px 38px rgba(0, 0, 0, 0.28);
+        }
+
+        .feed-evolucao-topo {
+            display: grid;
+            grid-template-columns: auto 1fr auto;
+            align-items: center;
+            gap: 10px;
+            padding: 12px;
+        }
+
+        .feed-evolucao-avatar,
+        .feed-evolucao-avatar-fallback {
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            object-fit: cover;
+        }
+
+        .feed-evolucao-avatar-fallback {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(255, 71, 87, 0.14);
+            color: #ff9aa2;
+            font-size: 0.78rem;
+            font-weight: 950;
+        }
+
+        .feed-evolucao-topo strong {
+            display: block;
+            color: var(--text-main);
+            font-size: 0.8rem;
+            font-weight: 950;
+            text-transform: none;
+        }
+
+        .feed-evolucao-topo span {
+            display: block;
+            color: var(--text-muted);
+            font-size: 0.72rem;
+            line-height: 1.35;
+            text-transform: none;
+        }
+
+        .feed-evolucao-topo time {
+            color: var(--text-soft);
+            font-size: 0.68rem;
+            white-space: nowrap;
+        }
+
+        .feed-evolucao-img,
+        .feed-evolucao-sem-img {
+            width: 100%;
+            height: 160px;
+            border-top: 1px solid rgba(255, 255, 255, 0.065);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.065);
+        }
+
+        .feed-evolucao-img {
+            object-fit: cover;
+            filter: brightness(0.94) contrast(1.06) saturate(1.05);
+        }
+
+        .feed-evolucao-sem-img {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0, 0, 0, 0.26);
+            color: var(--text-soft);
+            font-size: 0.72rem;
+            font-weight: 900;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        .feed-evolucao-corpo {
+            padding: 13px;
+        }
+
+        .feed-evolucao-tag {
+            display: inline-flex;
+            margin-bottom: 8px;
+            padding: 5px 8px;
+            border: 1px solid rgba(255, 71, 87, 0.22);
+            border-radius: var(--radius-pill);
+            background: rgba(255, 71, 87, 0.08);
+            color: #ff8b94;
+            font-size: 0.58rem;
+            font-weight: 950;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .feed-evolucao-corpo h3 {
+            margin: 0 0 7px;
+            color: var(--text-main);
+            font-size: 0.98rem;
+            font-weight: 950;
+            text-transform: none;
+        }
+
+        .feed-evolucao-corpo p {
+            margin: 0 0 12px;
+            color: var(--text-muted);
+            font-size: 0.8rem;
+            line-height: 1.45;
+            text-transform: none;
+        }
+
+        .feed-evolucao-abrir {
+            width: fit-content;
+            min-height: 34px;
+            margin: 0;
+            padding: 0 14px;
+            border-radius: var(--radius-pill);
+            background: rgba(255, 255, 255, 0.045);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            color: var(--text-main);
+            font-size: 0.62rem;
+            font-weight: 950;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            box-shadow: none;
+        }
+
+        .feed-evolucoes-vazio {
+            grid-column: 1 / -1;
+            padding: 18px;
+            color: var(--text-muted);
+            text-align: center;
         }
 
         .galeria {
@@ -5317,6 +5609,53 @@
                     border-radius: var(--radius-pill);
                 }
 
+                .feed-evolucoes {
+                    margin-bottom: 18px;
+                    padding: 14px;
+                    border-radius: 20px;
+                }
+
+                .feed-evolucoes-header {
+                    display: grid;
+                    gap: 7px;
+                    margin-bottom: 13px;
+                }
+
+                .feed-evolucoes-header h2 {
+                    font-size: 1.05rem;
+                }
+
+                .feed-evolucoes-header p {
+                    max-width: none;
+                    font-size: 0.76rem;
+                    text-align: left;
+                }
+
+                .feed-evolucoes-lista {
+                    grid-template-columns: 1fr;
+                    gap: 12px;
+                }
+
+                .feed-evolucao-topo {
+                    grid-template-columns: auto 1fr;
+                }
+
+                .feed-evolucao-topo time {
+                    grid-column: 2;
+                    justify-self: start;
+                    margin-top: -4px;
+                }
+
+                .feed-evolucao-img,
+                .feed-evolucao-sem-img {
+                    height: 175px;
+                }
+
+                .feed-evolucao-abrir {
+                    width: 100%;
+                    min-height: 38px;
+                }
+
                 .galeria {
                     gap: 18px;
                 }
@@ -5766,5 +6105,29 @@
                 .pagina-projeto .evolucao-imagem {
                     width: 100%;
                     max-height: 230px;
+                }
+
+                .app-nav {
+                    width: calc(100% - 24px);
+                    margin-bottom: 14px;
+                    gap: 4px;
+                    padding: 5px;
+                    border-radius: 20px;
+                }
+
+                .app-nav button {
+                    min-height: 40px;
+                    padding: 8px 9px;
+                    font-size: 0.58rem;
+                    letter-spacing: 0.045em;
+                }
+
+                .secao-encontros {
+                    width: calc(100% - 24px);
+                }
+
+                .secao-encontros-card {
+                    padding: 20px;
+                    border-radius: 20px;
                 }
             }


### PR DESCRIPTION
closes #180 


## Descrição

Esta PR separa o Diário da Garagem da tela inicial, transformando o feed de evoluções em uma seção principal acessada por navegação própria.

A mudança evita que o feed secundário apareça misturado com a listagem principal de projetos e começa a preparar a estrutura do app para futuras áreas, como a Central de Encontros.

## Escopo

- Cria uma navegação principal entre Garagem, Diário e Encontros.
- Mantém Garagem como seção inicial padrão.
- Move o Diário da Garagem para uma seção própria.
- Carrega o feed de evoluções ao acessar a seção Diário.
- Adiciona uma seção inicial de Encontros como placeholder visual.
- Ajusta estilos desktop e mobile para essa nova divisão.

## Banco de dados

Não houve alteração estrutural no banco.  
O arquivo `garagem_digital.sql` não precisou ser alterado.