### PR TITLE
style: refina header principal e navegação do app

### DIFF
--- a/script.js
+++ b/script.js
@@ -511,16 +511,15 @@
         }
 
         function obterOffsetHeaderApp() {
-            const header =
-                document.querySelector('.app-header') ||
-                document.querySelector('.header-app') ||
-                document.querySelector('.app-nav');
+            const header = document.querySelector('.app-shell-topo');
 
-            if (!header) {
-                return 110;
+            if (!header || header.style.display === 'none') {
+                return 24;
             }
 
-            return header.getBoundingClientRect().height + 28;
+            const margemExtra = window.innerWidth <= 768 ? 18 : 24;
+
+            return header.getBoundingClientRect().height + margemExtra;
         }
 
         function rolarParaElementoComHeader(elemento) {
@@ -613,14 +612,20 @@
                 botoes[secao].classList.add('ativo');
             }
 
+            if (secao !== 'garagem') {
+                fecharFormularioProjeto();
+            }
+
             if (secao === 'diario') {
                 carregarFeedEvolucoes();
             }
 
-            window.scrollTo({
-                top: 0,
-                left: 0,
-                behavior: 'smooth'
+            requestAnimationFrame(() => {
+                window.scrollTo({
+                    top: 0,
+                    left: 0,
+                    behavior: 'smooth'
+                });
             });
         }
 

--- a/style.css
+++ b/style.css
@@ -5685,13 +5685,13 @@
 
                 .app-shell-topo {
                     position: sticky;
-                    top: 10px;
+                    top: 8px;
                     width: calc(100% - 16px);
-                    grid-template-columns: 1fr auto;
+                    grid-template-columns: minmax(0, 1fr) auto;
                     gap: 8px;
-                    margin-bottom: 18px;
+                    margin: 0 auto 16px;
                     padding: 8px;
-                    border-radius: 24px;
+                    border-radius: 22px;
                 }
 
                 .app-brand {
@@ -5729,9 +5729,11 @@
                 .app-shell-topo .app-nav {
                     grid-column: 1 / -1;
                     width: 100%;
+                    margin: 0;
                     gap: 4px;
                     padding: 5px;
                     border-radius: 18px;
+                    box-sizing: border-box;
                 }
 
                 .app-shell-topo .app-nav button {
@@ -5745,6 +5747,7 @@
 
                 .app-shell-acoes {
                     grid-column: 1 / -1;
+                    width: 100%;
                 }
 
                 .app-shell-acoes .btn-toggle-form {
@@ -6330,41 +6333,6 @@
                 .pagina-projeto .evolucao-imagem {
                     width: 100%;
                     max-height: 230px;
-                }
-
-                .app-nav {
-                    width: calc(100% - 24px);
-                    max-width: none;
-                    margin: 0 auto 16px;
-                    gap: 5px;
-                    padding: 5px;
-                    border-radius: 22px;
-                    box-sizing: border-box;
-                }
-
-                .app-nav button {
-                    min-height: 42px;
-                    padding: 0 9px;
-                    border-radius: 17px;
-                    font-size: 0.58rem;
-                    letter-spacing: 0.045em;
-                    gap: 5px;
-                }
-
-                .app-nav button::before {
-                    width: 5px;
-                    height: 5px;
-                    box-shadow: none;
-                }
-
-                .app-nav button.ativo::before {
-                    width: 12px;
-                }
-
-                .app-nav button::after {
-                    left: 12px;
-                    right: 12px;
-                    bottom: 5px;
                 }
 
                 .secao-encontros {


### PR DESCRIPTION
## Resumo

Refina o header principal do Garagem Digital para deixar a navegação com aparência mais próxima de um app/site real.

## O que foi alterado

- Reorganiza o topo principal com marca, navegação, botão de novo projeto e perfil.
- Melhora a hierarquia visual do header no desktop.
- Ajusta o header no mobile para não ficar colado nas bordas.
- Melhora o comportamento ao abrir o formulário de novo projeto.
- Faz a troca entre Garagem, Diário e Encontros voltar para o topo.
- Mantém Diário e Encontros como áreas secundárias separadas da garagem principal.

## Banco de dados

Não houve alteração estrutural no banco de dados.

O arquivo `garagem_digital.sql` não precisou ser alterado.


Closes #186